### PR TITLE
fix: Avoid service to crash when Duty is null

### DIFF
--- a/src/thermostat.ts
+++ b/src/thermostat.ts
@@ -191,7 +191,7 @@ export class Thermostat {
       this.mqttClimate.currentTemperature = state.CorrectedTemp.v;
       this.mqttClimate.currentHumidity = state.Humidity.v;
       this.mqttClimate.currentMode = state.TstatMode.v === 1 ? 'off' : state.TstatMode.v === 3 ? 'heat' : undefined;
-      this.mqttClimate.currentAction = this.computeCurrentAction(undefined, state.Duty.v);
+      this.mqttClimate.currentAction = this.computeCurrentAction(undefined, state.Duty?.v ?? 0);
       this.mqttClimate.targetTemperature = this.mqttClimate.currentMode !== 'off' ? state.SetPoint.v : undefined;
       await this.mqttClimate.writeConfig();
 


### PR DESCRIPTION
When we have a mix of baseboards and Mini-Split the service keeps crashing as `Duty` is not available for Mini-Split.

This PR just set Duty to 0 if not provided allowing the service to work properly in a mixed environment.
Additionally, this provides partial support for AC-V1-1 where Temperatures, State (Heat only) and Humidity are retrieved and can be displayed in home assistant. Control of Mini-Split is of course not working.

<img width="657" height="482" alt="image" src="https://github.com/user-attachments/assets/762a2a53-447a-473b-981a-62d5b8d71ef4" />

Payload example for `AC-V1-1`
```
  "ACState": {
    "t": 1760597434,
    "v": {
      "1": 2,
      "2": 3,
      "3": 21,
      "4": 1,
      "5": 3,
      "9": 2,
      "98": 0
    }
  },
  "Brightness": {
    "t": 1760372410,
    "v": 100
  },
  "Connected": {
    "t": 1760597434,
    "v": true
  },
  "CorrectedTemp": {
    "t": 1760597434,
    "v": 21.2
  },
  "Current": {
    "t": 1760597269,
    "v": 0
  },
  "Delta": {
    "t": 1760597269,
    "v": 2
  },
  "Device": "<deviceID>",
  "FanSpeed": {
    "t": 1760597269,
    "v": 1
  },
  "FreeHeap": {
    "t": 1760597269,
    "v": 59650
  },
  "HoldTime": {
    "t": 1760372410,
    "v": -1
  },
  "Humidity": {
    "t": 1760597434,
    "v": 46
  },
  "IsThermostatic": {
    "t": 1760597269,
    "v": 0
  },
  "Lock": {
    "t": 1760372410,
    "v": 0
  },
  "MysaIntegration": true,
  "OffTime": {
    "t": 1760597269,
    "v": 0
  },
  "OnTime": {
    "t": 1760597269,
    "v": 30
  },
  "Rssi": {
    "t": 1760597269,
    "v": -84
  },
  "ScheduleMode": {
    "t": 1760372410,
    "v": 1
  },
  "SensorTemp": {
    "t": 1760597269,
    "v": 23.7
  },
  "SetPoint": {
    "t": 1760597434,
    "v": 21
  },
  "SwingState": {
    "t": 1760597269,
    "v": 3
  },
  "SwingStateHorizontal": {
    "t": 1760372410,
    "v": 12
  },
  "Timestamp": 1760597434,
  "TstatMode": {
    "t": 1760597434,
    "v": 3
  },
  "Voltage": {
    "t": 1760597269,
    "v": 240
  }
}
```