### PR TITLE
fix(ac): detect idle state for AC devices; add 60s REST polling

### DIFF
--- a/src/thermostat.ts
+++ b/src/thermostat.ts
@@ -344,8 +344,10 @@ export class Thermostat {
         MYSA_RAW_MODE_TO_DEVICE_MODE[state.TstatMode?.v as number] ?? this.mqttClimate.currentMode;
       this.mqttClimate.currentFanMode =
         MYSA_RAW_FAN_SPEED_TO_FAN_SPEED_MODE[state.FanSpeed?.v as number] ?? this.mqttClimate.currentFanMode;
-      this.mqttClimate.currentAction = this.computeCurrentAction(undefined, state.Duty?.v);
+      // Set targetTemperature before computeCurrentAction so the AC idle check
+      // (currentTemperature >= targetTemperature - 0.5) uses the fresh setpoint.
       this.mqttClimate.targetTemperature = this.mqttClimate.currentMode !== 'off' ? state.SetPoint?.v : undefined;
+      this.mqttClimate.currentAction = this.computeCurrentAction(undefined, state.Duty?.v);
 
       await this.mqttTemperature.setState(
         'state_topic',

--- a/src/thermostat.ts
+++ b/src/thermostat.ts
@@ -65,6 +65,7 @@ const MYSA_RAW_FAN_SPEED_TO_FAN_SPEED_MODE: Partial<Record<number, MysaFanSpeedM
 
 export class Thermostat {
   private isStarted = false;
+  private _pollTimer?: ReturnType<typeof setInterval>;
   private readonly mqttDevice: DeviceConfiguration;
   private readonly mqttOrigin: OriginConfiguration;
   private readonly mqttClimate: Climate;
@@ -288,6 +289,14 @@ export class Thermostat {
       this.mysaApiClient.emitter.on('stateChanged', this.mysaStateChangeHandler);
 
       await this.mysaApiClient.startRealtimeUpdates(this.mysaDevice.Id);
+
+      // Poll device state every 60 seconds to supplement real-time AWS IoT MQTT events.
+      // For AC (mini-split) devices the real-time heartbeat fires only every ~7 minutes,
+      // meaning mode/temperature changes can take up to 7 minutes to appear in Home
+      // Assistant.  REST polling keeps state fresh without exceeding Mysa API rate limits.
+      this._pollTimer = setInterval(async () => {
+        await this.pollDeviceState();
+      }, 60_000);
     } catch (error) {
       this.isStarted = false;
       throw error;
@@ -301,6 +310,9 @@ export class Thermostat {
 
     this.isStarted = false;
 
+    clearInterval(this._pollTimer);
+    this._pollTimer = undefined;
+
     await this.mysaApiClient.stopRealtimeUpdates(this.mysaDevice.Id);
 
     this.mysaApiClient.emitter.off('statusChanged', this.mysaStatusUpdateHandler);
@@ -309,6 +321,40 @@ export class Thermostat {
     await this.mqttPower.setState('state_topic', 'None');
     await this.mqttTemperature.setState('state_topic', 'None');
     await this.mqttHumidity.setState('state_topic', 'None');
+  }
+
+  /**
+   * Polls the Mysa REST API for the current device state and updates MQTT accordingly.
+   * Called on a 60-second interval started in {@link start} to keep Home Assistant state
+   * fresh for AC (mini-split) devices whose real-time AWS IoT MQTT heartbeat fires only
+   * every ~7 minutes.
+   */
+  private async pollDeviceState() {
+    if (!this.isStarted) {
+      return;
+    }
+
+    try {
+      const deviceStates = await this.mysaApiClient.getDeviceStates();
+      const state = deviceStates.DeviceStatesObj[this.mysaDevice.Id];
+
+      this.mqttClimate.currentTemperature = state.CorrectedTemp?.v;
+      this.mqttClimate.currentHumidity = state.Humidity?.v;
+      this.mqttClimate.currentMode =
+        MYSA_RAW_MODE_TO_DEVICE_MODE[state.TstatMode?.v as number] ?? this.mqttClimate.currentMode;
+      this.mqttClimate.currentFanMode =
+        MYSA_RAW_FAN_SPEED_TO_FAN_SPEED_MODE[state.FanSpeed?.v as number] ?? this.mqttClimate.currentFanMode;
+      this.mqttClimate.currentAction = this.computeCurrentAction(undefined, state.Duty?.v);
+      this.mqttClimate.targetTemperature = this.mqttClimate.currentMode !== 'off' ? state.SetPoint?.v : undefined;
+
+      await this.mqttTemperature.setState(
+        'state_topic',
+        state.CorrectedTemp != null ? state.CorrectedTemp.v.toFixed(2) : 'None'
+      );
+      await this.mqttHumidity.setState('state_topic', state.Humidity != null ? state.Humidity.v.toFixed(2) : 'None');
+    } catch (error) {
+      this.logger.warn(`Poll failed: ${error}`);
+    }
   }
 
   private async handleMysaStatusUpdate(status: Status) {
@@ -379,8 +425,18 @@ export class Thermostat {
               return current > 0 ? 'heating' : 'idle';
             }
             return (dutyCycle ?? 0) > 0 ? 'heating' : 'idle';
-          default:
+          default: {
+            // AC (mini-split) devices do not report current draw, so we cannot use the
+            // BB device's current/dutyCycle approach.  Instead, compare room temperature
+            // to the heating setpoint with a 0.5 °C deadband: if the room is already
+            // within 0.5 °C of the target the unit has reached temperature and is idle.
+            const currentTemp = this.mqttClimate.currentTemperature;
+            const targetTemp = this.mqttClimate.targetTemperature;
+            if (currentTemp != null && targetTemp != null && currentTemp >= targetTemp - 0.5) {
+              return 'idle';
+            }
             return 'heating';
+          }
         }
       case 'cool':
         return 'cooling';


### PR DESCRIPTION
## Summary

Two fixes for **AC device types** (mini-split heat pumps controlled via Mysa GX), plus one ordering fix discovered during live testing.

### Fix 1: AC devices always reported `heating` action

`computeCurrentAction()` had a `default: return 'heating'` branch that applied to all non-BB device types. A Mysa GX connected to a mini-split would always show `action: heating` in Home Assistant regardless of whether the room had reached the target temperature.

**Fix:** for AC devices in `heat` mode, compare `currentTemperature` to `targetTemperature` with a 0.5 °C deadband. If the room is within 0.5 °C of the setpoint → `idle`; otherwise → `heating`.

### Fix 2: AC device state stale for up to 7 minutes

The real-time AWS IoT MQTT path (`startRealtimeUpdates`) sends heartbeats only every ~7 minutes for AC devices (Mysa SDK constant: `RealtimeKeepAliveInterval = 5 minutes`, heartbeats arrive ~every 7 minutes). A mode or setpoint change would not be reflected in Home Assistant for up to 7 minutes.

**Fix:** after `startRealtimeUpdates` in `start()`, a 60-second `setInterval` calls the new `pollDeviceState()` helper, which fetches the full device state via the `getDeviceStates()` REST API and updates all MQTT climate fields. The timer is cleared in `stop()`. Poll errors are caught and logged as warnings.

### Fix 3: ordering bug in `pollDeviceState`

The AC idle check in `computeCurrentAction` reads `this.mqttClimate.targetTemperature`. In the initial `pollDeviceState` implementation `currentAction` was computed *before* `targetTemperature` was updated, so the first poll after startup used the stale (potentially `undefined`) setpoint and always returned `heating`.

**Fix:** swap the order in `pollDeviceState` — assign `targetTemperature` from the fresh API response *before* calling `computeCurrentAction`.

Discovered during live testing: room at 18.2 °C with setpoint 18 °C; action stayed `heating` after the first poll because `targetTemperature` was still `undefined` from startup.

## Devices tested

| Component | Details |
|-----------|---------|
| Mysa thermostat | **Mysa GX** (model `AC-V1-0`, firmware v3.17.5.9, serial SDGW2PXD66) |
| Heat pump | **Daikin mini-split** (BT series, controlled via Mysa GX IR blaster — no direct power reporting) |
| mysa2mqtt | v1.2.2 |
| mysa-js-sdk | v2.0.3 |
| Deployment | Kubernetes pod, `imagePullPolicy: IfNotPresent` |
| Home Assistant | 2025.x, MQTT integration |

## Changes

- `src/thermostat.ts`: add `_pollTimer` field; fix `computeCurrentAction` heat/AC branch with 0.5 °C deadband; add `pollDeviceState()` method; start/clear poll timer in `start()`/`stop()`; fix field ordering in `pollDeviceState`

## Notes

- The 60 s poll interval was chosen to stay well within Mysa API rate limits while keeping HA state acceptably fresh.
- The 0.5 °C deadband matches the `temp_step` already used for AC setpoints, avoiding spurious `heating`↔`idle` flapping near the setpoint.
- BB (baseboard heater) devices are unaffected — their existing current/duty-cycle logic is unchanged.
