### PR TITLE
fix: retry startup on transient network errors

### DIFF
--- a/.changeset/brave-onions-retry.md
+++ b/.changeset/brave-onions-retry.md
@@ -1,0 +1,7 @@
+---
+'mysa2mqtt': patch
+---
+
+Retry startup on transient network errors instead of exiting immediately. DNS, TCP or TLS hiccups during the initial
+Cognito authentication (surfaced as generic `Network error` by `amazon-cognito-identity-js`) are now retried up to 10
+times with exponential backoff before the process gives up. Configuration and programming errors still exit immediately.

--- a/.changeset/brave-onions-retry.md
+++ b/.changeset/brave-onions-retry.md
@@ -2,6 +2,4 @@
 'mysa2mqtt': patch
 ---
 
-Retry startup on transient network errors instead of exiting immediately. DNS, TCP or TLS hiccups during the initial
-Cognito authentication (surfaced as generic `Network error` by `amazon-cognito-identity-js`) are now retried up to 10
-times with exponential backoff before the process gives up. Configuration and programming errors still exit immediately.
+Retry startup on transient network errors instead of exiting immediately. DNS, TCP or TLS hiccups during the initial Cognito authentication (surfaced as generic `Network error` by `amazon-cognito-identity-js`) are now retried up to 10 times with exponential backoff before the process gives up. Configuration and programming errors still exit immediately.

--- a/packages/mysa2mqtt/src/main.ts
+++ b/packages/mysa2mqtt/src/main.ts
@@ -354,7 +354,49 @@ async function retryThermostatStart(thermostat: Thermostat, retryAttempt: number
   }
 }
 
-main().catch((error) => {
-  rootLogger.fatal(error, 'Unexpected error');
-  process.exit(1);
-});
+/**
+ * Determine whether an error thrown during bootstrap is a transient network/DNS issue worth retrying, vs. a
+ * configuration or programming error that should surface immediately.
+ *
+ * Mysa's auth path goes through AWS Cognito, which occasionally returns generic "Network error" failures from
+ * amazon-cognito-identity-js when DNS resolution, TCP connect, or TLS handshake hiccups. Without retry, the process
+ * fatally exits and the container/orchestrator restarts the whole thing — noisy and easily mistaken for a real outage.
+ *
+ * @param error - The thrown value caught from `main()`
+ * @returns `true` if the error is one of the network/DNS error shapes we should retry
+ */
+function isTransientNetworkError(error: unknown): boolean {
+  const code = (error as { code?: string })?.code;
+  const message = String((error as { message?: string })?.message ?? error ?? '');
+  const transientCodes = new Set(['NetworkError', 'ETIMEDOUT', 'ECONNRESET', 'ENOTFOUND', 'EAI_AGAIN']);
+  if (code && transientCodes.has(code)) return true;
+  return /Network error|getaddrinfo|socket hang up|timeout/i.test(message);
+}
+
+/** Bootstrap wrapper that retries `main()` on transient network errors with exponential backoff. */
+async function mainWithRetry(): Promise<void> {
+  const MAX_ATTEMPTS = 10;
+  const MAX_DELAY_MS = 60_000;
+  let delayMs = 5_000;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      await main();
+      return;
+    } catch (error) {
+      const transient = isTransientNetworkError(error);
+      if (!transient || attempt === MAX_ATTEMPTS) {
+        rootLogger.fatal(error, 'Unexpected error');
+        process.exit(1);
+      }
+      rootLogger.warn(
+        { err: error, attempt, maxAttempts: MAX_ATTEMPTS, retryInMs: delayMs },
+        `Transient error during startup (attempt ${attempt}/${MAX_ATTEMPTS}); retrying in ${delayMs}ms`
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      delayMs = Math.min(delayMs * 2, MAX_DELAY_MS);
+    }
+  }
+}
+
+mainWithRetry();

--- a/packages/mysa2mqtt/src/main.ts
+++ b/packages/mysa2mqtt/src/main.ts
@@ -368,30 +368,40 @@ async function retryThermostatStart(thermostat: Thermostat, retryAttempt: number
 function isTransientNetworkError(error: unknown): boolean {
   const code = (error as { code?: string })?.code;
   const message = String((error as { message?: string })?.message ?? error ?? '');
+
   const transientCodes = new Set(['NetworkError', 'ETIMEDOUT', 'ECONNRESET', 'ENOTFOUND', 'EAI_AGAIN']);
   if (code && transientCodes.has(code)) return true;
-  return /Network error|getaddrinfo|socket hang up|timeout/i.test(message);
+
+  // Network-specific message shapes always retry.
+  if (/Network error|getaddrinfo|socket hang up/i.test(message)) return true;
+
+  // A "timeout" is only transient when it names a network operation. A bare "timeout" can come from
+  // configuration or programming errors (e.g. a promise/test timeout), which must surface immediately.
+  const networkContext = /connect|connection|socket|network|request|handshake|tls|dns|host/i;
+  return /time(?:d\s*)?out|ETIMEDOUT/i.test(message) && networkContext.test(message);
 }
 
 /** Bootstrap wrapper that retries `main()` on transient network errors with exponential backoff. */
 async function mainWithRetry(): Promise<void> {
-  const MAX_ATTEMPTS = 10;
+  const MAX_RETRIES = 10;
   const MAX_DELAY_MS = 60_000;
   let delayMs = 5_000;
 
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+  // One initial attempt plus up to MAX_RETRIES retries on transient network errors.
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
       await main();
       return;
     } catch (error) {
       const transient = isTransientNetworkError(error);
-      if (!transient || attempt === MAX_ATTEMPTS) {
+      if (!transient || attempt === MAX_RETRIES) {
         rootLogger.fatal(error, 'Unexpected error');
         process.exit(1);
       }
+      const retry = attempt + 1;
       rootLogger.warn(
-        { err: error, attempt, maxAttempts: MAX_ATTEMPTS, retryInMs: delayMs },
-        `Transient error during startup (attempt ${attempt}/${MAX_ATTEMPTS}); retrying in ${delayMs}ms`
+        { err: error, retry, maxRetries: MAX_RETRIES, retryInMs: delayMs },
+        `Transient error during startup (retry ${retry}/${MAX_RETRIES}); retrying in ${delayMs}ms`
       );
       await new Promise((resolve) => setTimeout(resolve, delayMs));
       delayMs = Math.min(delayMs * 2, MAX_DELAY_MS);


### PR DESCRIPTION
## Summary

Wrap \`main()\` in a retry loop with exponential backoff that classifies network/DNS/timeout errors as transient and retries up to 10 times before fatally exiting. Non-transient errors still exit immediately.

## Motivation

Mysa auth goes through AWS Cognito. The \`amazon-cognito-identity-js\` client throws generic \`Network error\` (\`code: 'NetworkError'\`) on DNS/TCP/TLS hiccups during session refresh. Without retry, the process fatally exits and whatever supervises it (kubelet, systemd, Docker restart-policy) restarts the whole thing.

In a Kubernetes deployment I was seeing ~1.5 unnecessary restarts/day, each surfaced as a CrashLoopBackOff blip and each requiring a fresh Cognito login. After this patch, transient hiccups are logged at \`warn\` level with attempt context and recovered in-process.

Stack from a typical occurrence:

\`\`\`
[FATAL] Unexpected error
    err: {
      "type": "Error",
      "message": "Network error",
      "stack": Error: Network error
              at /app/node_modules/amazon-cognito-identity-js/lib/Client.js:113:15
              at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
      "code": "NetworkError"
    }
\`\`\`

## Behavior

| Error type | Before | After |
|---|---|---|
| Transient network (\`NetworkError\`, \`ETIMEDOUT\`, \`ECONNRESET\`, \`ENOTFOUND\`, \`EAI_AGAIN\`, or message matching \`/Network error\|getaddrinfo\|socket hang up\|timeout/i\`) | fatal exit | retry with backoff (5s → 10s → 20s → ... cap 60s, max 10 attempts) |
| Anything else | fatal exit | unchanged — fatal exit on first occurrence |

## Tested

- \`npm run lint\` ✅
- \`npm run style-lint\` ✅
- \`npm run build\` ✅
- Hand-tested in production deployment (running 6+ days previously, ~1.5 restarts/day from this exact stack); patched build has been running cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by automatically retrying transient network or DNS-style errors during initial authentication.
  * Added exponential backoff between retry attempts, up to 10 attempts before giving up.
  * Configuration and programming errors still stop startup immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->