### PR TITLE
docs: regenerate the contributor table after the monorepo merge

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,7 +1,5 @@
 {
-  "files": [
-    "README.md"
-  ],
+  "files": ["README.md"],
   "imageSize": 100,
   "commit": false,
   "commitType": "docs",
@@ -12,54 +10,49 @@
       "name": "remiolivier",
       "avatar_url": "https://avatars.githubusercontent.com/u/1379047?v=4",
       "profile": "https://github.com/remiolivier",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Terwox",
       "name": "James Myers",
       "avatar_url": "https://avatars.githubusercontent.com/u/17753313?v=4",
       "profile": "https://github.com/Terwox",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "jagmandan",
       "name": "jagmandan",
       "avatar_url": "https://avatars.githubusercontent.com/u/227265405?v=4",
       "profile": "https://github.com/jagmandan",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "vavallee",
       "name": "vavallee",
       "avatar_url": "https://avatars.githubusercontent.com/u/75899046?v=4",
       "profile": "https://getbindery.dev",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "olicarbo",
       "name": "Olivier Carbonneau",
       "avatar_url": "https://avatars.githubusercontent.com/u/1908784?v=4",
       "profile": "http://olicarbo.me",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "dxdc",
       "name": "Daniel Caspi",
       "avatar_url": "https://avatars.githubusercontent.com/u/7200365?v=4",
       "profile": "https://element26.net",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
+    },
+    {
+      "login": "souvik101990",
+      "name": "souvik101990",
+      "avatar_url": "https://avatars.githubusercontent.com/u/247682655?v=4",
+      "profile": "https://github.com/souvik101990",
+      "contributions": ["code"]
     }
   ],
   "contributorsPerLine": 7,
@@ -69,3 +62,4 @@
   "projectName": "mysa2mqtt",
   "projectOwner": "bourquep"
 }
+

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # mysa2mqtt
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-
-[![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors-)
-
+[![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![NPM Version](https://img.shields.io/npm/v/mysa2mqtt)](https://www.npmjs.com/package/mysa2mqtt)
@@ -83,6 +81,11 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/remiolivier"><img src="https://avatars.githubusercontent.com/u/1379047?v=4?s=100" width="100px;" alt="remiolivier"/><br /><sub><b>remiolivier</b></sub></a><br /><a href="https://github.com/bourquep/mysa2mqtt/commits?author=remiolivier" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Terwox"><img src="https://avatars.githubusercontent.com/u/17753313?v=4?s=100" width="100px;" alt="James Myers"/><br /><sub><b>James Myers</b></sub></a><br /><a href="https://github.com/bourquep/mysa2mqtt/commits?author=Terwox" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/jagmandan"><img src="https://avatars.githubusercontent.com/u/227265405?v=4?s=100" width="100px;" alt="jagmandan"/><br /><sub><b>jagmandan</b></sub></a><br /><a href="https://github.com/bourquep/mysa2mqtt/commits?author=jagmandan" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://getbindery.dev"><img src="https://avatars.githubusercontent.com/u/75899046?v=4?s=100" width="100px;" alt="vavallee"/><br /><sub><b>vavallee</b></sub></a><br /><a href="https://github.com/bourquep/mysa2mqtt/commits?author=vavallee" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="http://olicarbo.me"><img src="https://avatars.githubusercontent.com/u/1908784?v=4?s=100" width="100px;" alt="Olivier Carbonneau"/><br /><sub><b>Olivier Carbonneau</b></sub></a><br /><a href="https://github.com/bourquep/mysa2mqtt/commits?author=olicarbo" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://element26.net"><img src="https://avatars.githubusercontent.com/u/7200365?v=4?s=100" width="100px;" alt="Daniel Caspi"/><br /><sub><b>Daniel Caspi</b></sub></a><br /><a href="https://github.com/bourquep/mysa2mqtt/commits?author=dxdc" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/souvik101990"><img src="https://avatars.githubusercontent.com/u/247682655?v=4?s=100" width="100px;" alt="souvik101990"/><br /><sub><b>souvik101990</b></sub></a><br /><a href="https://github.com/bourquep/mysa2mqtt/commits?author=souvik101990" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
The monorepo merge combined the three repos' `.all-contributorsrc` files into one at the root (6 people), and the badge was updated to match — but the contributor **table** in the README was copied verbatim from the old mysa2mqtt README and only ever listed 2.

So four people — jagmandan, vavallee, olicarbo and dxdc — were credited in the data file and counted in the badge, but did not appear anywhere visible. My oversight in #149.

Regenerated the table from `.all-contributorsrc` with `all-contributors-cli`.

Also folds in **souvik101990**, which is what PR #147 was doing before the restructure invalidated it. #146 (adding vavallee) is now redundant — vavallee came across in the merged `.all-contributorsrc` — so both bot PRs can be closed once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the All Contributors badge to reflect the latest contributor count.
  * Added new contributor information to the README.
  * Refined contributor metadata formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->