### PR TITLE
fix: guard MQTT publishes against never-arriving acknowledgements

### DIFF
--- a/.changeset/plain-crabs-report.md
+++ b/.changeset/plain-crabs-report.md
@@ -1,0 +1,10 @@
+---
+'mysa-js-sdk': patch
+---
+
+Fixed `startRealtimeUpdates` hanging forever when the Mysa broker silently ignores a `START_PUBLISHING_DEVICE_STATUS`
+publish. QoS1 publishes now time out after 30 seconds if no acknowledgement arrives (observed in production since July
+2026: the broker drops these publishes without a PUBACK, and the client's 60s protocol operation timeout never fires). A
+failed status-publishing request no longer aborts realtime startup and a failed keep-alive no longer surfaces as an
+unhandled rejection — both are logged as warnings, since the device's autonomous periodic status reports (message
+type 30) keep flowing over the subscription either way.

--- a/packages/mysa-js-sdk/src/api/MysaApiClient.ts
+++ b/packages/mysa-js-sdk/src/api/MysaApiClient.ts
@@ -49,6 +49,7 @@ const CognitoLoginKey = `cognito-idp.${AwsRegion}.amazonaws.com/${CognitoUserPoo
 const MqttEndpoint = 'a3q27gia9qg3zy-ats.iot.us-east-1.amazonaws.com';
 const MysaApiBaseUrl = 'https://app-prod.mysa.cloud';
 const RealtimeKeepAliveInterval = dayjs.duration(5, 'minutes');
+const PublishAckTimeout = dayjs.duration(30, 'seconds');
 
 /**
  * Main client for interacting with the Mysa API and real-time device communication.
@@ -522,19 +523,32 @@ export class MysaApiClient {
       Timestamp: dayjs().unix(),
       Timeout: RealtimeKeepAliveInterval.asSeconds()
     });
-    await this._publishWithRetry(mqttConnection, `/v1/dev/${deviceId}/in`, payload, mqtt.QoS.AtLeastOnce);
+
+    // A failed publish request must not abort startup (or, in the keep-alive
+    // below, crash the process via an unhandled rejection): the subscription
+    // above still delivers the device's autonomous periodic status reports
+    // even when the request-driven status stream is unavailable.
+    try {
+      await this._publishWithRetry(mqttConnection, `/v1/dev/${deviceId}/in`, payload, mqtt.QoS.AtLeastOnce);
+    } catch (error) {
+      this._logger.warn(`Failed to request status publishing for '${deviceId}'; relying on periodic reports`, error);
+    }
 
     const timer = setInterval(async () => {
       this._logger.debug(`Sending request to keep-alive publishing device status for '${deviceId}'...`);
 
-      const connection = await this._getMqttConnection();
-      const payload = serializeMqttPayload<StartPublishingDeviceStatus>({
-        Device: deviceId,
-        MsgType: InMessageType.START_PUBLISHING_DEVICE_STATUS,
-        Timestamp: dayjs().unix(),
-        Timeout: RealtimeKeepAliveInterval.asSeconds()
-      });
-      await this._publishWithRetry(connection, `/v1/dev/${deviceId}/in`, payload, mqtt.QoS.AtLeastOnce);
+      try {
+        const connection = await this._getMqttConnection();
+        const payload = serializeMqttPayload<StartPublishingDeviceStatus>({
+          Device: deviceId,
+          MsgType: InMessageType.START_PUBLISHING_DEVICE_STATUS,
+          Timestamp: dayjs().unix(),
+          Timeout: RealtimeKeepAliveInterval.asSeconds()
+        });
+        await this._publishWithRetry(connection, `/v1/dev/${deviceId}/in`, payload, mqtt.QoS.AtLeastOnce);
+      } catch (error) {
+        this._logger.warn(`Failed to keep-alive status publishing for '${deviceId}'`, error);
+      }
     }, RealtimeKeepAliveInterval.subtract(10, 'seconds').asMilliseconds());
 
     this._realtimeDeviceIds.set(deviceId, timer);
@@ -696,7 +710,27 @@ export class MysaApiClient {
     while (true) {
       attempt++;
       try {
-        await connection.publish(topic, payload, qos);
+        // Guard against publishes that never settle: a QoS1 publish the
+        // broker silently ignores (e.g. an unauthorized topic) produces no
+        // PUBACK and, in practice, no protocol-timeout rejection either —
+        // the pending await would otherwise hang this call chain forever.
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(
+            () =>
+              reject(new Error(`MQTT publish timeout: no acknowledgement within ${PublishAckTimeout.asSeconds()}s`)),
+            PublishAckTimeout.asMilliseconds()
+          );
+          connection.publish(topic, payload, qos).then(
+            () => {
+              clearTimeout(timer);
+              resolve();
+            },
+            (err) => {
+              clearTimeout(timer);
+              reject(err);
+            }
+          );
+        });
         return;
       } catch (err) {
         const isTransient = this._isTransientMqttError(err);


### PR DESCRIPTION
## Summary

This is the remaining piece of the fork pin flagged in #129 (`github:vavallee/mysa-js-sdk#d419a08`) that is **not** covered by mysa-js-sdk 2.1.1 — everything else in that pin (#215, #216, #217) already landed here.

Since ~July 2026 the Mysa broker silently drops `START_PUBLISHING_DEVICE_STATUS` publishes to `/v1/dev/{id}/in`: no PUBACK arrives, and in practice the connection's `with_protocol_operation_timeout_ms(60000)` never fires for these either, so the QoS1 publish promise never settles. `startRealtimeUpdates` then hangs before the keep-alive timer is created, taking the caller's startup with it. (The bridge-level hardening from #130 can't help here — it retries throws, and this path never throws.)

Two changes in `MysaApiClient`:

- **`_publishWithRetry` races every publish against a 30s ack timeout.** The timeout error message matches the existing transient classification (`/timeout/i`), so the retry/backoff and `MqttPublishError` semantics work as designed instead of hanging.
- **Status-publishing requests are no longer fatal.** The initial `START_PUBLISHING_DEVICE_STATUS` publish is wrapped in try/catch (warn), and so is the keep-alive publish — which previously surfaced as an unhandled rejection inside `setInterval`. The `/out` subscription alone still delivers the device's autonomous periodic status reports (msg type 30, parsed since #215), so realtime data keeps flowing either way.

## Validation

- `npm run lint`, `npm run typecheck`, `npm run build`, `npm run style-lint` all pass
- Running in my k8s deployment since 2026-07-17 (as part of the fork pin): thermostats that previously wedged at startup now come up and stream type-30 reports

## Contributing checklist

- Conventional commit: `fix: guard MQTT publishes against never-arriving acknowledgements`
- Changeset: `mysa-js-sdk` patch included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed real-time updates becoming stuck when the broker does not acknowledge a publish request.
  * Added a timeout for publish acknowledgements so connection attempts can recover instead of waiting indefinitely.
  * Real-time update startup now continues when an optional status-publishing request fails.
  * Prevented keep-alive failures from causing unhandled errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->