### PR TITLE
feat: add --heartbeat-file data-freshness heartbeat

### DIFF
--- a/.changeset/tidy-camels-beat.md
+++ b/.changeset/tidy-camels-beat.md
@@ -1,0 +1,8 @@
+---
+'mysa2mqtt': minor
+---
+
+Added `--heartbeat-file` / `M2M_HEARTBEAT_FILE`: when set, mysa2mqtt touches the given file on every message received
+from the Mysa cloud (throttled to one write per 10 seconds). External supervisors can watch the file's mtime to detect a
+wedged cloud connection and restart the process — for example a Kubernetes exec liveness probe checking that the file is
+fresher than 15 minutes.

--- a/packages/mysa2mqtt/README.md
+++ b/packages/mysa2mqtt/README.md
@@ -156,6 +156,7 @@ take precedence over command-line defaults.
 | `-f, --log-format`        | `M2M_LOG_FORMAT`        | `pretty`       | Log format: `pretty`, `json`                                            |
 | `-s, --mysa-session-file` | `M2M_MYSA_SESSION_FILE` | `session.json` | Path to Mysa session file                                               |
 | `-t, --temperature-unit`  | `M2M_TEMPERATURE_UNIT`  | `C`            | Temperature unit (`C` = Celsius, `F` = Fahrenheit)                      |
+| `--heartbeat-file`        | `M2M_HEARTBEAT_FILE`    | -              | File touched on every message received from the Mysa cloud, for external liveness checks (e.g. a container liveness probe on its mtime) |
 
 ## Usage Examples
 

--- a/packages/mysa2mqtt/src/main.ts
+++ b/packages/mysa2mqtt/src/main.ts
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+import { writeFile } from 'fs/promises';
 import { MqttSettings } from 'mqtt2ha';
 import { MysaApiClient } from 'mysa-js-sdk';
 import { pino } from 'pino';
@@ -62,6 +63,25 @@ async function main() {
   client.emitter.on('sessionChanged', async (newSession) => {
     await saveSession(newSession, options.mysaSessionFile, rootLogger);
   });
+
+  const heartbeatFile = options.heartbeatFile;
+  if (heartbeatFile) {
+    // Data-freshness heartbeat: an orchestrator liveness probe can compare
+    // this file's mtime against the expected message cadence (devices report
+    // at least every ~5 minutes while keep-alives flow) and restart the
+    // process when the Mysa cloud connection wedges without emitting errors.
+    let lastBeat = 0;
+    client.emitter.on('rawRealtimeMessageReceived', () => {
+      const now = Date.now();
+      if (now - lastBeat < 10_000) {
+        return;
+      }
+      lastBeat = now;
+      writeFile(heartbeatFile, `${new Date(now).toISOString()}\n`).catch((error) => {
+        rootLogger.warn(error, `Failed to write heartbeat file '${heartbeatFile}'`);
+      });
+    });
+  }
 
   if (!client.isAuthenticated) {
     rootLogger.info('Logging in...');

--- a/packages/mysa2mqtt/src/options.ts
+++ b/packages/mysa2mqtt/src/options.ts
@@ -150,5 +150,13 @@ export const options = new Command('mysa2mqtt')
       .default('C')
       .helpGroup('Configuration')
   )
+  .addOption(
+    new Option(
+      '--heartbeat-file <heartbeatFile>',
+      'file touched on every message received from the Mysa cloud, for external liveness checks'
+    )
+      .env('M2M_HEARTBEAT_FILE')
+      .helpGroup('Configuration')
+  )
   .parse()
   .opts();


### PR DESCRIPTION
## Summary

Adds `--heartbeat-file` / `M2M_HEARTBEAT_FILE`: when set, mysa2mqtt touches the file on every message received from the Mysa cloud (via `rawRealtimeMessageReceived`, throttled to one write per 10s). An external supervisor can watch the file's mtime and restart the process when data stops flowing.

## Motivation

The Mysa cloud connection can wedge without emitting any error or event — I observed 9 days of frozen data with zero log output and a healthy-looking process. Failure modes the app can't see from the inside need an out-of-band data-freshness signal. In my Kubernetes deployment this drives an exec liveness probe:

```yaml
livenessProbe:
  exec:
    command: [sh, -c, "find /tmp/mysa2mqtt-heartbeat -mmin -15 2>/dev/null | grep -q ."]
  initialDelaySeconds: 300
  periodSeconds: 60
```

(Healthy cadence is ≤5 min while keep-alives flow, so 15 minutes of silence means the connection is gone.) The same works with systemd watchdog wrappers or a plain cron check.

This has been running in my deployment since 2026-07-17 and has caught real silent wedges that nothing else surfaced.

## Validation

- `npm run lint`, `npm run typecheck`, `npm run build`, `npm run style-lint` all pass
- README options table updated

## Contributing checklist

- Conventional commit: `feat: add --heartbeat-file data-freshness heartbeat`
- Changeset: `mysa2mqtt` minor included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional heartbeat file that is updated when messages are received, enabling external monitoring to detect stalled connections.
  * Added support for configuring the heartbeat file through the command line or environment variable.

* **Documentation**
  * Documented the new heartbeat file configuration option and its monitoring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->