### PR TITLE
fix: stop prose-wrapping changelogs and changesets

### DIFF
--- a/packages/mqtt2ha/CHANGELOG.md
+++ b/packages/mqtt2ha/CHANGELOG.md
@@ -4,18 +4,12 @@
 
 ### Patch Changes
 
-- [#149](https://github.com/bourquep/mysa2mqtt/pull/149)
-  [`89e2950`](https://github.com/bourquep/mysa2mqtt/commit/89e2950c4874db14ea9b682380c63984aaf7a9f4) Thanks
-  [@bourquep](https://github.com/bourquep)! - Moved development into the
-  [mysa2mqtt monorepo](https://github.com/bourquep/mysa2mqtt).
+- [#149](https://github.com/bourquep/mysa2mqtt/pull/149) [`89e2950`](https://github.com/bourquep/mysa2mqtt/commit/89e2950c4874db14ea9b682380c63984aaf7a9f4) Thanks [@bourquep](https://github.com/bourquep)! - Moved development into the [mysa2mqtt monorepo](https://github.com/bourquep/mysa2mqtt).
 
-  There are no functional changes in this release. The package's repository and homepage links now point at the
-  monorepo, and issues for all three packages are tracked at https://github.com/bourquep/mysa2mqtt/issues.
+  There are no functional changes in this release. The package's repository and homepage links now point at the monorepo, and issues for all three packages are tracked at https://github.com/bourquep/mysa2mqtt/issues.
 
 ## Releases prior to 4.1.3
 
-This package previously lived in its own repository and used semantic-release, which published its release notes to
-GitHub Releases rather than to a changelog file.
+This package previously lived in its own repository and used semantic-release, which published its release notes to GitHub Releases rather than to a changelog file.
 
-See the [release history of the archived repository](https://github.com/bourquep/mqtt2ha/releases) for notes on versions
-up to and including 4.1.3.
+See the [release history of the archived repository](https://github.com/bourquep/mqtt2ha/releases) for notes on versions up to and including 4.1.3.

--- a/packages/mysa-js-sdk/CHANGELOG.md
+++ b/packages/mysa-js-sdk/CHANGELOG.md
@@ -4,18 +4,12 @@
 
 ### Patch Changes
 
-- [#149](https://github.com/bourquep/mysa2mqtt/pull/149)
-  [`89e2950`](https://github.com/bourquep/mysa2mqtt/commit/89e2950c4874db14ea9b682380c63984aaf7a9f4) Thanks
-  [@bourquep](https://github.com/bourquep)! - Moved development into the
-  [mysa2mqtt monorepo](https://github.com/bourquep/mysa2mqtt).
+- [#149](https://github.com/bourquep/mysa2mqtt/pull/149) [`89e2950`](https://github.com/bourquep/mysa2mqtt/commit/89e2950c4874db14ea9b682380c63984aaf7a9f4) Thanks [@bourquep](https://github.com/bourquep)! - Moved development into the [mysa2mqtt monorepo](https://github.com/bourquep/mysa2mqtt).
 
-  There are no functional changes in this release. The package's repository and homepage links now point at the
-  monorepo, and issues for all three packages are tracked at https://github.com/bourquep/mysa2mqtt/issues.
+  There are no functional changes in this release. The package's repository and homepage links now point at the monorepo, and issues for all three packages are tracked at https://github.com/bourquep/mysa2mqtt/issues.
 
 ## Releases prior to 2.1.0
 
-This package previously lived in its own repository and used semantic-release, which published its release notes to
-GitHub Releases rather than to a changelog file.
+This package previously lived in its own repository and used semantic-release, which published its release notes to GitHub Releases rather than to a changelog file.
 
-See the [release history of the archived repository](https://github.com/bourquep/mysa-js-sdk/releases) for notes on
-versions up to and including 2.1.0.
+See the [release history of the archived repository](https://github.com/bourquep/mysa-js-sdk/releases) for notes on versions up to and including 2.1.0.

--- a/packages/mysa2mqtt/CHANGELOG.md
+++ b/packages/mysa2mqtt/CHANGELOG.md
@@ -4,23 +4,16 @@
 
 ### Patch Changes
 
-- [#149](https://github.com/bourquep/mysa2mqtt/pull/149)
-  [`89e2950`](https://github.com/bourquep/mysa2mqtt/commit/89e2950c4874db14ea9b682380c63984aaf7a9f4) Thanks
-  [@bourquep](https://github.com/bourquep)! - Moved development into the
-  [mysa2mqtt monorepo](https://github.com/bourquep/mysa2mqtt).
+- [#149](https://github.com/bourquep/mysa2mqtt/pull/149) [`89e2950`](https://github.com/bourquep/mysa2mqtt/commit/89e2950c4874db14ea9b682380c63984aaf7a9f4) Thanks [@bourquep](https://github.com/bourquep)! - Moved development into the [mysa2mqtt monorepo](https://github.com/bourquep/mysa2mqtt).
 
-  There are no functional changes in this release. The package's repository and homepage links now point at the
-  monorepo, and issues for all three packages are tracked at https://github.com/bourquep/mysa2mqtt/issues.
+  There are no functional changes in this release. The package's repository and homepage links now point at the monorepo, and issues for all three packages are tracked at https://github.com/bourquep/mysa2mqtt/issues.
 
-- Updated dependencies
-  [[`89e2950`](https://github.com/bourquep/mysa2mqtt/commit/89e2950c4874db14ea9b682380c63984aaf7a9f4)]:
+- Updated dependencies [[`89e2950`](https://github.com/bourquep/mysa2mqtt/commit/89e2950c4874db14ea9b682380c63984aaf7a9f4)]:
   - mysa-js-sdk@2.1.1
   - mqtt2ha@4.1.4
 
 ## Releases prior to 1.2.3
 
-This package previously lived in a standalone repository and used semantic-release, which published its release notes to
-GitHub Releases rather than to a changelog file.
+This package previously lived in a standalone repository and used semantic-release, which published its release notes to GitHub Releases rather than to a changelog file.
 
-See the [release history](https://github.com/bourquep/mysa2mqtt/releases) for notes on versions up to and including
-1.2.3. Those releases are tagged `v1.2.3`; releases from the monorepo onwards are tagged `mysa2mqtt@<version>`.
+See the [release history](https://github.com/bourquep/mysa2mqtt/releases) for notes on versions up to and including 1.2.3. Those releases are tagged `v1.2.3`; releases from the monorepo onwards are tagged `mysa2mqtt@<version>`.

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -7,5 +7,16 @@ module.exports = {
   trailingComma: 'none',
   arrowParens: 'always',
   tsdoc: true,
-  plugins: ['prettier-plugin-organize-imports', 'prettier-plugin-jsdoc']
+  plugins: ['prettier-plugin-organize-imports', 'prettier-plugin-jsdoc'],
+  overrides: [
+    {
+      // Changesets copies these into GitHub Release bodies, which render with
+      // GFM hard line breaks -- every source newline becomes a <br>. Wrapping
+      // at printWidth counts markdown link *source* (mostly URL), so a "120
+      // character" line can render as a handful of visible words. Leave these
+      // unwrapped and let GitHub reflow them.
+      files: ['CHANGELOG.md', '.changeset/*.md'],
+      options: { proseWrap: 'preserve' }
+    }
+  ]
 };


### PR DESCRIPTION
The [mysa2mqtt@1.2.4 release notes](https://github.com/bourquep/mysa2mqtt/releases/tag/mysa2mqtt%401.2.4) break mid-sentence four times inside a single bullet:

```
89e2950 Thanks
@bourquep! - Moved development into the
mysa2mqtt monorepo.
```

## Cause

Two things combine.

**Prettier hard-wraps the source.** `proseWrap: 'always'` with `printWidth: 120` wraps at 120 *source* characters — but markdown links are mostly URL. This commit link is ~100 characters of source that renders as 7 visible ones, so a legitimately-120-character line renders as `89e2950 Thanks`. Changesets runs its generated changelog through the project's prettier config, so this applies to every release.

**GitHub renders release bodies with GFM hard line breaks.** A single newline becomes `<br>` rather than collapsing into the paragraph. So each of prettier's wrap points becomes a visible break.

That's why it only looks wrong there — the same file viewed as `CHANGELOG.md` in the repo renders fine, because standalone `.md` files use CommonMark semantics where those newlines are soft.

## Fix

`proseWrap: 'preserve'` for `CHANGELOG.md` and `.changeset/*.md`, so changesets' single-line output survives and GitHub reflows it to the container.

Both patterns are needed. `.changeset/*.md` is where it starts: the changeset summary is wrapped before changesets ever copies it into the changelog, so covering only `CHANGELOG.md` would still let hard breaks leak in from the source side.

Everything else keeps `proseWrap: 'always'` — README, CONTRIBUTING and AGENTS are read as files, where wrapping is invisible and keeps diffs reviewable.

Existing changelog entries are unwrapped so they match the shape future generated entries will have.

## Verified

- `prettier.resolveConfig` returns `preserve` for `packages/*/CHANGELOG.md` and `.changeset/*.md`, `always` for `README.md`, `CONTRIBUTING.md`, `AGENTS.md`
- Added a scratch changeset with a long summary and ran `changeset version`: the generated entry came out at **294** and **216** characters on one line each, instead of wrapping at 120
- `style-lint`, `lint`, `build` pass; prettier is idempotent over the rewritten changelogs; `changeset status` still parses them

## Note

This only affects future releases. The published 1.2.4 release body is a stored copy, not a live render of the file, so it needs editing directly if you want it fixed retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated historical release notes with clearer formatting and links.
  - Preserved details about the monorepo transition, release history, and the absence of functional changes in earlier releases.
- **Style**
  - Improved Markdown formatting consistency across changelogs and changeset files.
  - Preserved intentional line wrapping to improve rendered readability on GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->