### PR TITLE
fix(mysa2mqtt): apply modeless state changes instead of dropping them

### DIFF
--- a/.changeset/modeless-state-changes.md
+++ b/.changeset/modeless-state-changes.md
@@ -1,0 +1,6 @@
+---
+'mysa2mqtt': patch
+---
+
+Apply state changes that arrive without an operating mode instead of silently dropping them. Home Assistant no longer
+shows a stale target temperature (or fan speed) when Mysa pushes a modeless update.

--- a/packages/mysa2mqtt/src/thermostat.ts
+++ b/packages/mysa2mqtt/src/thermostat.ts
@@ -447,6 +447,19 @@ export class Thermostat {
         this.mqttClimate.currentAction = this.computeCurrentAction();
         this.mqttClimate.currentFanMode = state.fanSpeed;
         break;
+
+      default:
+        // A state change without a mode still carries a valid setPoint (and
+        // possibly a fan speed). Apply what we received without touching the
+        // mode or action — dropping the whole update left Home Assistant
+        // showing a stale target temperature.
+        if (this.mqttClimate.currentMode !== 'off') {
+          this.mqttClimate.targetTemperature = state.setPoint;
+        }
+        if (state.fanSpeed !== undefined) {
+          this.mqttClimate.currentFanMode = state.fanSpeed;
+        }
+        break;
     }
   }
 


### PR DESCRIPTION
## Summary

`handleMysaStateChange` switched on `state.mode` with no default branch, so a state change arriving without a mode was silently discarded even though `setPoint` is always present on the event (and `fanSpeed` sometimes is). Home Assistant kept showing a stale target temperature.

The new default branch applies what the update carries without touching `currentMode` or `currentAction`, per the approach in the issue. Two judgment calls:

- `targetTemperature` is only updated when the current mode isn't `off`, mirroring the guard `handleMysaStatusChange` already uses so an off device doesn't sprout a target.
- `currentFanMode` is only updated when the event actually carries a `fanSpeed`, so a modeless update from a non-AC device can't wipe an AC's fan state with `undefined`.

Happy to adjust either if you'd rather have the unconditional assignments.

Changeset included (`mysa2mqtt` patch).

Fixes #159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Applied thermostat state updates that arrive without an operating mode.
  * Prevented stale target temperature and fan speed values in Home Assistant.
  * Preserved the current operating mode and action when processing modeless updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->