### PR TITLE
fix(mqtt2ha): guard async MQTT callbacks against unhandled rejections

### DIFF
--- a/.changeset/guard-async-mqtt-callbacks.md
+++ b/.changeset/guard-async-mqtt-callbacks.md
@@ -1,0 +1,6 @@
+---
+'mqtt2ha': patch
+---
+
+Errors thrown while subscribing to command topics or handling a received command are now caught and logged instead of
+escaping as unhandled promise rejections, which could terminate the process under Node's default rejection policy.

--- a/packages/mqtt2ha/src/api/subscriber.ts
+++ b/packages/mqtt2ha/src/api/subscriber.ts
@@ -92,8 +92,16 @@ export class Subscriber<
       throw new Error('No command topics provided');
     }
 
+    // The MQTT client does not await or observe its listeners, so any
+    // rejection escaping these async callbacks becomes an unhandled promise
+    // rejection and terminates the process under Node's default policy.
+    // Catch and log instead.
     super(settings, stateTopicNames, onStateChange, async () => {
-      await this.subscribeToCommandTopics();
+      try {
+        await this.subscribeToCommandTopics();
+      } catch (error) {
+        this.logger.error(`Failed to subscribe to command topics for ${this.identifier}`, error);
+      }
     });
 
     this.commandCallback = commandCallback;
@@ -104,7 +112,11 @@ export class Subscriber<
     }));
 
     this.mqttClient.on('message', async (topic, message) => {
-      await this.handleCommandMessage(topic, message);
+      try {
+        await this.handleCommandMessage(topic, message);
+      } catch (error) {
+        this.logger.error(`Failed to handle command message for ${this.identifier} on topic ${topic}`, error);
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

Both async callbacks in `subscriber.ts` ran with nothing observing their promises: the connection callback passed to `super()` (calling `subscribeToCommandTopics`) and the `message` listener (calling `handleCommandMessage`). An EventEmitter doesn't await its listeners, so a broker disconnect mid-subscribe or a throwing command handler became an unhandled rejection, which terminates the process under Node's default policy.

Both bodies are now wrapped in try/catch and report through `this.logger`, matching the message-first error idiom already used in `discoverable.ts`. No behaviour change on the success path.

Changeset included (`mqtt2ha` patch).

Fixes #150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented subscription errors from becoming unhandled promise rejections.
  * Prevented command-processing failures from terminating the application.
  * Added clearer error logging for subscription and command message handling failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->