### PR TITLE
chore: unwrap changeset prose with proseWrap 'never'

### DIFF
--- a/.changeset/guard-async-mqtt-callbacks.md
+++ b/.changeset/guard-async-mqtt-callbacks.md
@@ -2,5 +2,4 @@
 'mqtt2ha': patch
 ---
 
-Errors thrown while subscribing to command topics or handling a received command are now caught and logged instead of
-escaping as unhandled promise rejections, which could terminate the process under Node's default rejection policy.
+Errors thrown while subscribing to command topics or handling a received command are now caught and logged instead of escaping as unhandled promise rejections, which could terminate the process under Node's default rejection policy.

--- a/.changeset/modeless-state-changes.md
+++ b/.changeset/modeless-state-changes.md
@@ -2,5 +2,4 @@
 'mysa2mqtt': patch
 ---
 
-Apply state changes that arrive without an operating mode instead of silently dropping them. Home Assistant no longer
-shows a stale target temperature (or fan speed) when Mysa pushes a modeless update.
+Apply state changes that arrive without an operating mode instead of silently dropping them. Home Assistant no longer shows a stale target temperature (or fan speed) when Mysa pushes a modeless update.

--- a/.changeset/plain-crabs-report.md
+++ b/.changeset/plain-crabs-report.md
@@ -2,9 +2,4 @@
 'mysa-js-sdk': patch
 ---
 
-Fixed `startRealtimeUpdates` hanging forever when the Mysa broker silently ignores a `START_PUBLISHING_DEVICE_STATUS`
-publish. QoS1 publishes now time out after 30 seconds if no acknowledgement arrives (observed in production since July
-2026: the broker drops these publishes without a PUBACK, and the client's 60s protocol operation timeout never fires). A
-failed status-publishing request no longer aborts realtime startup and a failed keep-alive no longer surfaces as an
-unhandled rejection — both are logged as warnings, since the device's autonomous periodic status reports (message
-type 30) keep flowing over the subscription either way.
+Fixed `startRealtimeUpdates` hanging forever when the Mysa broker silently ignores a `START_PUBLISHING_DEVICE_STATUS` publish. QoS1 publishes now time out after 30 seconds if no acknowledgement arrives (observed in production since July 2026: the broker drops these publishes without a PUBACK, and the client's 60s protocol operation timeout never fires). A failed status-publishing request no longer aborts realtime startup and a failed keep-alive no longer surfaces as an unhandled rejection — both are logged as warnings, since the device's autonomous periodic status reports (message type 30) keep flowing over the subscription either way.

--- a/.changeset/tidy-camels-beat.md
+++ b/.changeset/tidy-camels-beat.md
@@ -2,7 +2,4 @@
 'mysa2mqtt': minor
 ---
 
-Added `--heartbeat-file` / `M2M_HEARTBEAT_FILE`: when set, mysa2mqtt touches the given file on every message received
-from the Mysa cloud (throttled to one write per 10 seconds). External supervisors can watch the file's mtime to detect a
-wedged cloud connection and restart the process — for example a Kubernetes exec liveness probe checking that the file is
-fresher than 15 minutes.
+Added `--heartbeat-file` / `M2M_HEARTBEAT_FILE`: when set, mysa2mqtt touches the given file on every message received from the Mysa cloud (throttled to one write per 10 seconds). External supervisors can watch the file's mtime to detect a wedged cloud connection and restart the process — for example a Kubernetes exec liveness probe checking that the file is fresher than 15 minutes.

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -13,10 +13,15 @@ module.exports = {
       // Changesets copies these into GitHub Release bodies, which render with
       // GFM hard line breaks -- every source newline becomes a <br>. Wrapping
       // at printWidth counts markdown link *source* (mostly URL), so a "120
-      // character" line can render as a handful of visible words. Leave these
-      // unwrapped and let GitHub reflow them.
+      // character" line can render as a handful of visible words.
+      //
+      // 'never' rather than 'preserve': preserve only stops prettier adding
+      // wraps, so a changeset written with hard-wrapped prose still carries
+      // those breaks into the changelog. 'never' unwraps each paragraph onto
+      // one line, which also makes `style-lint` fail on a wrapped changeset
+      // instead of letting it reach a release.
       files: ['CHANGELOG.md', '.changeset/*.md'],
-      options: { proseWrap: 'preserve' }
+      options: { proseWrap: 'never' }
     }
   ]
 };


### PR DESCRIPTION
Follow-up to #185, which did not fully fix the problem — #184's release notes still break mid-sentence.

## What #185 got wrong

It set `proseWrap: 'preserve'` for `CHANGELOG.md` and `.changeset/*.md`. That only stops prettier from **adding** wraps; it cannot **remove** ones already in the file. Every pending changeset was authored hard-wrapped at ~120 characters:

```
117| Errors thrown while subscribing to command topics or handling a received command are now caught and logged instead of
114| escaping as unhandled promise rejections, which could terminate the process under Node's default rejection policy.
```

Those breaks flowed straight through into the changelog and out to the GitHub release body, which renders single newlines as `<br>`.

## Fix

`proseWrap: 'never'`, which unwraps each paragraph onto one line. Paragraph breaks are preserved; only intra-paragraph wrapping is removed.

The important secondary effect: **the rule is now self-enforcing.** Under `preserve` all four pending changesets passed `style-lint`; under `never` all four fail it, and `npm run style-fix` repairs them. A wrapped changeset can no longer reach a release unnoticed.

## Verified properly this time

The verification in #185 was invalid: it ran `changeset version` with output suppressed, which **failed silently** because `@changesets/changelog-github` needs a `GITHUB_TOKEN` to resolve PR links. The character counts reported as proof were just the entry that had been unwrapped by hand — the generation path was never exercised.

Re-run with a token, against the real pending changesets:

| package | entry | before | after |
|---|---|---|---|
| `mqtt2ha` | 4.1.5 | 2 lines (324 + 116) | **1 line, 439 chars** |
| `mysa-js-sdk` | 2.1.2 | 6 wrapped lines | **1 line, 852 chars** |
| `mysa2mqtt` | 1.3.0 / patch | wrapped | **1 line each, 593 / 408 chars** |

Multi-paragraph summaries keep their blank-line separation; nested dependency lists stay as their own list items.

Also confirmed: `style-lint` fails before the fix and passes after, and prettier is idempotent over the result.

## After merging

#184 will regenerate against the corrected changesets on its next run. The already-published 1.2.4 release body is a stored copy and still needs a manual edit if you want it fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional heartbeat file setting for monitoring cloud connectivity and detecting stalled updates.
* **Bug Fixes**
  * State updates without an operating mode are now applied correctly, preventing stale temperature or fan settings.
  * Improved handling of command and status-publishing errors to prevent unexpected process termination.
  * Status publishing now times out gracefully when the broker does not respond, while background updates continue.
  * Keep-alive and message-processing failures are logged as warnings instead of becoming unhandled errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->