### PR TITLE
ci: comment on released PRs with their published versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,9 +115,12 @@ jobs:
       pull-requests: write
 
     steps:
+      # This job only reads the repo; `gh` authenticates via GH_TOKEN below, so
+      # there is no need to leave a credential in .git/config.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # `@changesets/changelog-github` has already resolved every changeset to
       # its originating PR, so the CHANGELOG diff of the version commit is an

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       id-token: write # npm provenance
     outputs:
       published: ${{ steps.changesets.outputs.published }}
+      published_packages: ${{ steps.changesets.outputs.publishedPackages }}
       mysa2mqtt_version: ${{ steps.m2m.outputs.version }}
 
     steps:
@@ -99,3 +100,74 @@ jobs:
           tags: |
             bourquep/mysa2mqtt:${{ needs.release.outputs.mysa2mqtt_version }}
             bourquep/mysa2mqtt:latest
+
+  # Replaces the "released in version x" comments semantic-release used to post.
+  # Runs after `docker` so the comment can only claim an image tag that exists.
+  comment:
+    needs: [release, docker]
+    # `docker` is skipped when no mysa2mqtt release happened, which would skip
+    # this job too under the default `needs` semantics — hence the explicit
+    # result check rather than plain `needs.release.outputs.published`.
+    if: ${{ !cancelled() && needs.release.outputs.published == 'true' && needs.docker.result != 'failure' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # `@changesets/changelog-github` has already resolved every changeset to
+      # its originating PR, so the CHANGELOG diff of the version commit is an
+      # exact per-package list of the PRs in this release. Attribution comes
+      # from which package's CHANGELOG a PR landed in, so a PR touching two
+      # packages gets a single comment listing both versions.
+      - name: Comment on released PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PUBLISHED: ${{ needs.release.outputs.published_packages }}
+          M2M_VERSION: ${{ needs.release.outputs.mysa2mqtt_version }}
+        run: |
+          set -euo pipefail
+          lines=$(mktemp -d)
+
+          while IFS=$'\t' read -r name version; do
+            dir=''
+            for candidate in packages/*/; do
+              if [ "$(jq -r .name "$candidate/package.json")" = "$name" ]; then
+                dir="$candidate"
+                break
+              fi
+            done
+            if [ -z "$dir" ]; then
+              echo "::warning::no package directory found for $name, skipping"
+              continue
+            fi
+
+            entry="- \`$name@$version\` — [npm](https://www.npmjs.com/package/$name/v/$version)"
+            if [ "$name" = 'mysa2mqtt' ] && [ -n "$M2M_VERSION" ]; then
+              entry="$entry, Docker \`bourquep/mysa2mqtt:$M2M_VERSION\`"
+            fi
+
+            # `|| true`: a package whose CHANGELOG entry is only "Updated
+            # dependencies" has no PR links, and grep's exit 1 would trip `set -e`.
+            prs=$(git show HEAD -- "$dir/CHANGELOG.md" \
+              | grep '^+' \
+              | grep -oE 'github\.com/[^/]+/[^/]+/pull/[0-9]+' \
+              | grep -oE '[0-9]+$' \
+              | sort -u || true)
+
+            for pr in $prs; do
+              printf '%s\n' "$entry" >> "$lines/$pr"
+            done
+          done < <(jq -r '.[] | [.name, .version] | @tsv' <<< "$PUBLISHED")
+
+          shopt -s nullglob
+          for f in "$lines"/*; do
+            pr=$(basename "$f")
+            echo "Commenting on #$pr"
+            { printf ':rocket: Released in:\n\n'; sort "$f"; } | gh pr comment "$pr" --body-file -
+          done


### PR DESCRIPTION
Restores the "released in version x" PR comments that semantic-release used to post, which Changesets has no built-in equivalent for.

## How it works

`@changesets/changelog-github` already resolves every changeset to its originating PR, so the `CHANGELOG.md` diff of the version commit is an exact per-package list of the PRs in a release. Attribution follows which package's changelog a PR landed in, so a PR touching several packages gets a single comment listing each published version.

Verified against the real `4f50f2e` release with `gh pr comment` stubbed out:

| PR | Comment |
|---|---|
| #182 | `mysa-js-sdk@2.1.2` |
| #183, #186 | `mysa2mqtt@1.3.0` + Docker tag |
| #187 | `mqtt2ha@4.1.5` |

Changeset-less chore PRs (#185, #188) correctly get nothing.

## Notes

- **Why a job and not an `on: release: [published]` workflow.** The usual drop-in for this is [`apexskier/github-release-commenter`](https://github.com/apexskier/github-release-commenter) triggered by the release event, but releases created with `GITHUB_TOKEN` do not trigger new workflow runs — that workflow would never fire without switching to a PAT.
- **Gating.** `needs: [release, docker]` alone would skip this job whenever `docker` is skipped (library-only releases), so the condition uses `!cancelled() && ... && needs.docker.result != 'failure'`. A failed Docker build suppresses the comments rather than advertising a tag that doesn't exist.
- **Behavior differs from semantic-release.** It commented on every PR in the commit range; this comments only on PRs that carried a changeset.

## Testing

Dry-run only, against the last release commit. `actionlint` is not installed locally, so the YAML was validated by Prettier's parser alone — the workflow is only truly exercised on the next real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated “Released in” notifications to pull requests that are included in published packages.
  * Release comments now list each published package with links to its npm version, and include a Docker image tag for the relevant package when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->