### PR TITLE
fix(sdk): rethrow payload parse failures instead of writing to console.error

### DIFF
--- a/.changeset/payload-parser-no-console.md
+++ b/.changeset/payload-parser-no-console.md
@@ -1,0 +1,5 @@
+---
+'mysa-js-sdk': patch
+---
+
+Payload parse failures no longer write to console.error, which bypassed the configurable SDK logger and could leak payload contents. The error is rethrown with the original failure attached as cause and logged by the message handler through the SDK logger.

--- a/packages/mysa-js-sdk/src/lib/PayloadParser.ts
+++ b/packages/mysa-js-sdk/src/lib/PayloadParser.ts
@@ -17,8 +17,14 @@ export function parseMqttPayload(payload: ArrayBuffer): OutPayload {
     const jsonString = decoder.decode(payload);
     return JSON.parse(jsonString);
   } catch (error) {
-    console.error('Error parsing MQTT payload:', error);
-    throw new Error('Failed to parse MQTT payload');
+    // No console output here: the SDK logger is the only sanctioned sink, and
+    // the raw payload must not leak into output the consumer cannot route or
+    // silence. The caller (_processMqttMessage) logs through the Logger.
+    // The cause is attached via assignment because the project's TS lib
+    // predates the ES2022 Error options constructor; Node supports it.
+    const parseError = new Error('Failed to parse MQTT payload');
+    (parseError as Error & { cause?: unknown }).cause = error;
+    throw parseError;
   }
 }
 


### PR DESCRIPTION
Fixes #164.

parseMqttPayload no longer calls console.error, which bypassed the configurable SDK logger and could leak payload contents into output the consumer cannot route or silence. The parse failure is rethrown with the original error attached as cause (via assignment, since the project's TS lib predates the ES2022 Error options constructor; Node supports the property at runtime). _processMqttMessage already logs the rethrown error through the SDK logger, so nothing is lost.

Gate run locally: style-lint, lint, build, typecheck all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MQTT payload parsing error handling.
  - Parsing failures are now routed through the SDK’s configurable logger instead of directly writing to the console.
  - Error details are preserved to support clearer diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->