### PR TITLE
fix(sdk): throw UnknownDeviceError for unrecognized device ids

### DIFF
--- a/.changeset/unknown-device-error.md
+++ b/.changeset/unknown-device-error.md
@@ -1,0 +1,5 @@
+---
+'mysa-js-sdk': patch
+---
+
+setDeviceState now throws a descriptive UnknownDeviceError when the device id does not match any device on the account, instead of failing with a raw TypeError on an undefined dereference.

--- a/packages/mysa-js-sdk/src/api/Errors.ts
+++ b/packages/mysa-js-sdk/src/api/Errors.ts
@@ -33,6 +33,19 @@ export class MysaApiError extends Error {
   }
 }
 
+/** Error thrown when a device id does not match any device on the account. */
+export class UnknownDeviceError extends Error {
+  /**
+   * Creates a new UnknownDeviceError instance.
+   *
+   * @param deviceId - The device id that could not be resolved
+   */
+  constructor(public readonly deviceId: string) {
+    super(`Unknown device id '${deviceId}': no such device on this account.`);
+    this.name = 'UnknownDeviceError';
+  }
+}
+
 /** Error thrown when an MQTT publish ultimately fails after retry attempts. */
 export class MqttPublishError extends Error {
   /**

--- a/packages/mysa-js-sdk/src/api/MysaApiClient.ts
+++ b/packages/mysa-js-sdk/src/api/MysaApiClient.ts
@@ -23,7 +23,7 @@ import { hash } from 'crypto';
 import dayjs, { Dayjs } from 'dayjs';
 import duration from 'dayjs/plugin/duration.js';
 import { customAlphabet } from 'nanoid';
-import { MqttPublishError, MysaApiError, UnauthenticatedError } from './Errors';
+import { MqttPublishError, MysaApiError, UnauthenticatedError, UnknownDeviceError } from './Errors';
 import { Logger, VoidLogger } from './Logger';
 import { MysaApiClientEventTypes } from './MysaApiClientEventTypes';
 import { MysaApiClientOptions } from './MysaApiClientOptions';
@@ -413,6 +413,7 @@ export class MysaApiClient {
    * @param fanSpeed - The fan speed mode to set ('low', 'medium', 'high', 'max', 'auto', or undefined to leave
    *   unchanged).
    * @throws {@link UnauthenticatedError} When the user is not authenticated.
+   * @throws {@link UnknownDeviceError} When the device id does not match any device on the account.
    * @throws {@link Error} When MQTT connection or command sending fails.
    */
   async setDeviceState(deviceId: string, setPoint?: number, mode?: MysaDeviceMode, fanSpeed?: MysaFanSpeedMode) {
@@ -423,6 +424,9 @@ export class MysaApiClient {
     }
 
     const device = this._cachedDevices.DevicesObj[deviceId];
+    if (!device) {
+      throw new UnknownDeviceError(deviceId);
+    }
 
     this._logger.debug(`Initializing MQTT connection...`);
     const mqttConnection = await this._getMqttConnection();


### PR DESCRIPTION
Fixes #158.

setDeviceState dereferenced the device cache lookup without checking it, so an unknown or stale device id died with a raw TypeError on .Model. It now throws a new UnknownDeviceError (exported from the api barrel like the other error classes, with the device id as a readonly field) right after the lookup. The setDeviceState doc block gained the matching @throws entry.

Gate run locally: style-lint, lint, build, typecheck all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `setDeviceState` now returns a clear `UnknownDeviceError` when the specified device cannot be found.
  - Error messages include the unrecognized device ID, replacing an unclear runtime failure.

- **Documentation**
  - Updated API documentation to describe the new error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->