### PR TITLE
fix: stop PinoLogger duplicating metadata and dropping falsy values

### DIFF
--- a/.changeset/pino-logger-meta.md
+++ b/.changeset/pino-logger-meta.md
@@ -1,0 +1,5 @@
+---
+'mysa2mqtt': patch
+---
+
+PinoLogger no longer passes the first metadata value twice (once as pino's merge object and again as an interpolation argument), and falsy-but-valid values like 0 or an empty string are now forwarded instead of being routed through the null branch.

--- a/packages/mysa2mqtt/src/logger.ts
+++ b/packages/mysa2mqtt/src/logger.ts
@@ -27,39 +27,24 @@ import pino from 'pino';
 export class PinoLogger implements Logger {
   constructor(private readonly logger: pino.Logger) {}
 
+  // meta[0] is pino's merge object and must not be repeated in the
+  // interpolation args (it was previously passed twice), and a valid falsy
+  // first value (0, '', false) must still be forwarded rather than dropped
+  // into the null branch — hence ?? instead of a truthiness check.
+
   debug(message: string, ...meta: unknown[]): void {
-    const obj = meta.at(0);
-    if (obj) {
-      this.logger.debug(obj, message, ...meta);
-    } else {
-      this.logger.debug(null, message, ...meta);
-    }
+    this.logger.debug(meta.at(0) ?? null, message, ...meta.slice(1));
   }
 
   info(message: string, ...meta: unknown[]): void {
-    const obj = meta.at(0);
-    if (obj) {
-      this.logger.info(obj, message, ...meta);
-    } else {
-      this.logger.info(null, message, ...meta);
-    }
+    this.logger.info(meta.at(0) ?? null, message, ...meta.slice(1));
   }
 
   warn(message: string, ...meta: unknown[]): void {
-    const obj = meta.at(0);
-    if (obj) {
-      this.logger.warn(obj, message, ...meta);
-    } else {
-      this.logger.warn(null, message, ...meta);
-    }
+    this.logger.warn(meta.at(0) ?? null, message, ...meta.slice(1));
   }
 
   error(message: string, ...meta: unknown[]): void {
-    const obj = meta.at(0);
-    if (obj) {
-      this.logger.error(obj, message, ...meta);
-    } else {
-      this.logger.error(null, message, ...meta);
-    }
+    this.logger.error(meta.at(0) ?? null, message, ...meta.slice(1));
   }
 }


### PR DESCRIPTION
Fixes #160.

All four level methods passed meta[0] as pino's merge object and then again inside ...meta, and the truthiness check sent valid falsy values (0, empty string, false) down the null branch. Each method now forwards meta.at(0) ?? null as the merge object and spreads meta.slice(1), which fixes both in one expression and collapses the duplicated branches.

Gate run locally: style-lint, lint, build, typecheck all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate metadata appearing in debug, info, warning, and error logs.
  * Preserved valid falsy metadata values, including `0`, empty strings, and `false`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->