### PR TITLE
fix: validate session file shape before using it as MysaSession

### DIFF
--- a/.changeset/validate-loaded-session.md
+++ b/.changeset/validate-loaded-session.md
@@ -1,0 +1,5 @@
+---
+'mysa2mqtt': patch
+---
+
+loadSession now validates the parsed session file against the expected MysaSession shape (string username and tokens) before returning it. A corrupted or truncated session file falls back to the normal no-valid-session path instead of surfacing later as a confusing downstream failure.

--- a/packages/mysa2mqtt/src/session.ts
+++ b/packages/mysa2mqtt/src/session.ts
@@ -26,6 +26,25 @@ import { MysaSession } from 'mysa-js-sdk';
 import pino from 'pino';
 
 /**
+ * Type guard validating that a parsed value has the shape of a MysaSession.
+ *
+ * @param value - The parsed JSON value to validate.
+ * @returns True when the value is a non-null object with the four required string token fields.
+ */
+function isMysaSession(value: unknown): value is MysaSession {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const session = value as Record<string, unknown>;
+  return (
+    typeof session.username === 'string' &&
+    typeof session.idToken === 'string' &&
+    typeof session.accessToken === 'string' &&
+    typeof session.refreshToken === 'string'
+  );
+}
+
+/**
  * Loads a Mysa session from a file.
  *
  * @param filename - The path to the file containing the session data.
@@ -36,7 +55,14 @@ export async function loadSession(filename: string, logger: pino.Logger): Promis
   try {
     logger.info('Loading Mysa session...');
     const sessionJson = await readFile(filename, 'utf8');
-    return JSON.parse(sessionJson);
+    const parsed: unknown = JSON.parse(sessionJson);
+    if (isMysaSession(parsed)) {
+      return parsed;
+    }
+    // Well-formed JSON of the wrong shape (a truncated write, {}, null, an
+    // array) used to be returned as-is and fail later in confusing ways;
+    // treat it like any other invalid session file instead.
+    logger.info('No valid Mysa session file found.');
   } catch {
     logger.info('No valid Mysa session file found.');
   }


### PR DESCRIPTION
Fixes #161.

loadSession returned JSON.parse output directly as MysaSession, so any well formed JSON ({}, null, an array, a truncated write) was accepted and blew up later somewhere confusing. Added an isMysaSession type guard requiring a non-null non-array object with string username, idToken, accessToken and refreshToken; anything else takes the existing no-valid-session path and logs the same message, after which the app falls back to a fresh login like it does for a missing file.

Gate run locally: style-lint, lint, build, typecheck all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session-file validation to detect corrupted, incomplete, or incorrectly formatted session data.
  * Invalid session files now follow the standard “no valid session” handling instead of causing failures later in the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->