### PR TITLE
fix: ignore non-numeric climate command payloads instead of storing NaN

### DIFF
--- a/.changeset/reject-nan-climate-commands.md
+++ b/.changeset/reject-nan-climate-commands.md
@@ -1,0 +1,5 @@
+---
+'mqtt2ha': patch
+---
+
+Numeric climate command payloads (target temperature, humidity, high/low bounds) are now validated: a payload that does not parse to a finite number is logged and ignored instead of storing NaN in state and republishing it.

--- a/packages/mqtt2ha/src/components/climate.ts
+++ b/packages/mqtt2ha/src/components/climate.ts
@@ -463,24 +463,57 @@ export class Climate extends Subscriber<ClimateInfo, StateTopicMap, CommandTopic
         this.currentSwingMode = message;
         break;
 
-      case 'target_humidity_command_topic':
-        this.targetHumidity = parseFloat(message);
+      case 'target_humidity_command_topic': {
+        const humidity = this.parseNumericCommand(topicName, message);
+        if (humidity !== undefined) {
+          this.targetHumidity = humidity;
+        }
         break;
+      }
 
-      case 'temperature_command_topic':
-        this.targetTemperature = parseFloat(message);
+      case 'temperature_command_topic': {
+        const temperature = this.parseNumericCommand(topicName, message);
+        if (temperature !== undefined) {
+          this.targetTemperature = temperature;
+        }
         break;
+      }
 
-      case 'temperature_high_command_topic':
-        this.temperatureHigh = parseFloat(message);
+      case 'temperature_high_command_topic': {
+        const temperatureHigh = this.parseNumericCommand(topicName, message);
+        if (temperatureHigh !== undefined) {
+          this.temperatureHigh = temperatureHigh;
+        }
         break;
+      }
 
-      case 'temperature_low_command_topic':
-        this.temperatureLow = parseFloat(message);
+      case 'temperature_low_command_topic': {
+        const temperatureLow = this.parseNumericCommand(topicName, message);
+        if (temperatureLow !== undefined) {
+          this.temperatureLow = temperatureLow;
+        }
         break;
+      }
 
       default:
         this.logger.warn('Received an unexpected command topic:', topicName);
     }
+  }
+
+  /**
+   * Parses a numeric command payload, returning undefined for anything that does not parse to a finite number so a
+   * malformed message is ignored instead of storing and republishing NaN.
+   *
+   * @param topicName - The command topic the payload arrived on (for the warning log)
+   * @param message - The raw command payload
+   * @returns The parsed finite number, or undefined when the payload is not numeric
+   */
+  private parseNumericCommand(topicName: string, message: string): number | undefined {
+    const value = parseFloat(message);
+    if (!Number.isFinite(value)) {
+      this.logger.warn(`Received a non-numeric payload on the '${topicName}':`, message);
+      return undefined;
+    }
+    return value;
   }
 }

--- a/packages/mqtt2ha/src/components/climate.ts
+++ b/packages/mqtt2ha/src/components/climate.ts
@@ -423,15 +423,28 @@ export class Climate extends Subscriber<ClimateInfo, StateTopicMap, CommandTopic
     onCommand: CommandCallback<CommandTopicMap>
   ) {
     super(settings, stateTopicNames, onStateChange, commandTopicNames, async (topicName, message) => {
-      await this.handleCommand(topicName, message);
-      await onCommand(topicName, message);
+      // A rejected command (e.g. a non-numeric payload on a numeric topic) must
+      // not reach the downstream command handler either: it was never applied
+      // locally, so forwarding it would trigger device side effects for a
+      // payload this component just refused to store.
+      if (await this.handleCommand(topicName, message)) {
+        await onCommand(topicName, message);
+      }
     });
   }
 
+  /**
+   * Applies a command payload to the local state.
+   *
+   * @param topicName - The command topic the payload arrived on
+   * @param message - The raw command payload
+   * @returns Whether the command was accepted; rejected payloads (a non-numeric value on a numeric topic) are not
+   *   applied and must not be forwarded to the downstream command handler
+   */
   private async handleCommand<TTopicName extends keyof CommandTopicMap & string>(
     topicName: TTopicName,
     message: CommandTopicMap[TTopicName]
-  ) {
+  ): Promise<boolean> {
     switch (topicName) {
       case 'fan_mode_command_topic':
         this.currentFanMode = message;
@@ -465,53 +478,62 @@ export class Climate extends Subscriber<ClimateInfo, StateTopicMap, CommandTopic
 
       case 'target_humidity_command_topic': {
         const humidity = this.parseNumericCommand(topicName, message);
-        if (humidity !== undefined) {
-          this.targetHumidity = humidity;
+        if (humidity === undefined) {
+          return false;
         }
+        this.targetHumidity = humidity;
         break;
       }
 
       case 'temperature_command_topic': {
         const temperature = this.parseNumericCommand(topicName, message);
-        if (temperature !== undefined) {
-          this.targetTemperature = temperature;
+        if (temperature === undefined) {
+          return false;
         }
+        this.targetTemperature = temperature;
         break;
       }
 
       case 'temperature_high_command_topic': {
         const temperatureHigh = this.parseNumericCommand(topicName, message);
-        if (temperatureHigh !== undefined) {
-          this.temperatureHigh = temperatureHigh;
+        if (temperatureHigh === undefined) {
+          return false;
         }
+        this.temperatureHigh = temperatureHigh;
         break;
       }
 
       case 'temperature_low_command_topic': {
         const temperatureLow = this.parseNumericCommand(topicName, message);
-        if (temperatureLow !== undefined) {
-          this.temperatureLow = temperatureLow;
+        if (temperatureLow === undefined) {
+          return false;
         }
+        this.temperatureLow = temperatureLow;
         break;
       }
 
       default:
         this.logger.warn('Received an unexpected command topic:', topicName);
     }
+
+    return true;
   }
 
   /**
-   * Parses a numeric command payload, returning undefined for anything that does not parse to a finite number so a
-   * malformed message is ignored instead of storing and republishing NaN.
+   * Parses a numeric command payload, returning undefined for anything that does not represent a finite number so a
+   * malformed message is ignored instead of storing and republishing NaN. Number(...) is used rather than parseFloat so
+   * partial inputs such as '21abc' are rejected instead of silently truncated. The raw payload is deliberately not
+   * logged: it is externally supplied and could carry an accidentally published secret.
    *
    * @param topicName - The command topic the payload arrived on (for the warning log)
    * @param message - The raw command payload
    * @returns The parsed finite number, or undefined when the payload is not numeric
    */
   private parseNumericCommand(topicName: string, message: string): number | undefined {
-    const value = parseFloat(message);
+    const trimmed = message.trim();
+    const value = trimmed === '' ? NaN : Number(trimmed);
     if (!Number.isFinite(value)) {
-      this.logger.warn(`Received a non-numeric payload on the '${topicName}':`, message);
+      this.logger.warn(`Received a non-numeric payload on the '${topicName}'.`);
       return undefined;
     }
     return value;


### PR DESCRIPTION
Fixes #162.

The four numeric command topics (targetHumidity, targetTemperature, temperatureHigh, temperatureLow) assigned parseFloat(message) unchecked, so a malformed payload stored NaN and republished it to state. They now go through a shared parseNumericCommand helper that requires Number.isFinite; invalid payloads get a warn log (same style as the existing unexpected-payload warnings) and are dropped without touching state.

Gate run locally: style-lint, lint, build, typecheck all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Climate numeric commands are now validated before being applied.
  * Invalid, non-numeric, empty, or infinite values are ignored and logged instead of being stored or republished as invalid state.
* **Chores**
  * Added a Changesets entry for the `mqtt2ha` package to publish the patch update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->