### PR TITLE
fix: forward TLS key, cert and CA settings to the MQTT client

### DIFF
--- a/.changeset/forward-tls-settings.md
+++ b/.changeset/forward-tls-settings.md
@@ -1,0 +1,5 @@
+---
+'mqtt2ha': patch
+---
+
+The tls_key, tls_certfile and tls_ca_cert settings are now actually forwarded to the MQTT client when use_tls is enabled. They were previously accepted and silently ignored, so mutual TLS setups connected without their configured certificates. The files are read at client creation and an unreadable path now fails loudly instead of degrading silently.

--- a/packages/mqtt2ha/src/api/discoverable.ts
+++ b/packages/mqtt2ha/src/api/discoverable.ts
@@ -21,6 +21,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+import { readFileSync } from 'fs';
 import { connect, MqttClient } from 'mqtt';
 import { BaseComponentConfiguration, ResolvedComponentConfiguration } from '../configuration/component_configuration';
 import { Logger, VoidLogger } from '../lib/logger';
@@ -144,6 +145,18 @@ export class Discoverable<
     }));
 
     this.logger.debug(`Creating MQTT client for ${identifier}...`);
+    // The TLS settings hold file paths while mqtt.js expects the key and
+    // certificate contents, so they are read here at client creation. A
+    // missing or unreadable file throws immediately: silently connecting
+    // without the configured certificates is the one behaviour a security
+    // setting must never have.
+    const tlsOptions = settings.mqtt.use_tls
+      ? {
+          key: settings.mqtt.tls_key ? readFileSync(settings.mqtt.tls_key) : undefined,
+          cert: settings.mqtt.tls_certfile ? readFileSync(settings.mqtt.tls_certfile) : undefined,
+          ca: settings.mqtt.tls_ca_cert ? readFileSync(settings.mqtt.tls_ca_cert) : undefined
+        }
+      : undefined;
     const client = connect({
       host: settings.mqtt.host,
       port: settings.mqtt.port,
@@ -151,6 +164,7 @@ export class Discoverable<
       password: settings.mqtt.password,
       clientId: `${settings.mqtt.client_name}-${identifier}`,
       protocol: settings.mqtt.use_tls ? 'mqtts' : 'mqtt',
+      ...tlsOptions,
       will: !this.settings.manual_availability
         ? {
             topic: this.availabilityTopic,


### PR DESCRIPTION
Fixes #155.

connect() selected the mqtts protocol but never passed tls_key, tls_certfile or tls_ca_cert, so mutual TLS configurations silently connected without their certificates. The settings hold file paths while mqtt.js expects contents, so the files are read (readFileSync) at client creation when use_tls is on and forwarded as key, cert and ca. A missing or unreadable file now throws immediately, which is the failure mode you want from a security setting; the non-TLS path is untouched.

Gate run locally: style-lint, lint, build, typecheck all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TLS key, certificate, and CA settings are now correctly applied when secure MQTT connections are enabled.
  * Invalid or unreadable certificate paths now produce a clear failure instead of being silently ignored.

* **Documentation**
  * Updated documentation to clarify TLS file handling and connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->