### PR TITLE
fix: observe state-changed handler completion in setState and setStateSync

### DIFF
--- a/.changeset/await-state-changed-handler.md
+++ b/.changeset/await-state-changed-handler.md
@@ -1,0 +1,5 @@
+---
+'mqtt2ha': patch
+---
+
+setState now awaits the state-changed handler, so callers that await setState observe handler completion and failures instead of racing it. setStateSync keeps its synchronous shape but attaches error logging to the handler promise, so a rejection is surfaced through the logger instead of escaping as an unhandled rejection that can terminate the process.

--- a/packages/mqtt2ha/src/api/discoverable.ts
+++ b/packages/mqtt2ha/src/api/discoverable.ts
@@ -283,12 +283,18 @@ export class Discoverable<
       retain: true
     });
 
-    // The synchronous API cannot await the handler, but its rejection must
-    // not go unobserved (an unhandled rejection terminates the process under
-    // Node's default policy).
-    Promise.resolve(this.stateChangedHandler(topicName, state)).catch((error: unknown) => {
+    // The synchronous API cannot await the handler, but its failure must not
+    // go unobserved (an unhandled rejection terminates the process under
+    // Node's default policy). The try/catch covers a handler that throws
+    // synchronously before returning a promise — Promise.resolve only
+    // captures rejections, not the synchronous throw itself.
+    try {
+      Promise.resolve(this.stateChangedHandler(topicName, state)).catch((error: unknown) => {
+        this.logger.error(`State-changed handler failed for ${this.identifier} on topic ${topicName}`, error);
+      });
+    } catch (error) {
       this.logger.error(`State-changed handler failed for ${this.identifier} on topic ${topicName}`, error);
-    });
+    }
   }
 
   /**

--- a/packages/mqtt2ha/src/api/discoverable.ts
+++ b/packages/mqtt2ha/src/api/discoverable.ts
@@ -283,7 +283,12 @@ export class Discoverable<
       retain: true
     });
 
-    this.stateChangedHandler(topicName, state);
+    // The synchronous API cannot await the handler, but its rejection must
+    // not go unobserved (an unhandled rejection terminates the process under
+    // Node's default policy).
+    Promise.resolve(this.stateChangedHandler(topicName, state)).catch((error: unknown) => {
+      this.logger.error(`State-changed handler failed for ${this.identifier} on topic ${topicName}`, error);
+    });
   }
 
   /**
@@ -309,6 +314,7 @@ export class Discoverable<
       { retain: true }
     );
 
-    this.stateChangedHandler(topicName, state);
+    // Awaited so callers of setState observe handler completion and failures.
+    await this.stateChangedHandler(topicName, state);
   }
 }


### PR DESCRIPTION
Fixes #154.

setState awaited publishAsync but fired the state-changed handler without awaiting it, so awaiting callers continued before the handler finished and never saw its failures. It now awaits the handler. setStateSync keeps its synchronous API but wraps the handler call in Promise.resolve().catch() with an error log, so a rejection lands in the logger instead of escaping as an unhandled rejection (which kills the process under Node's default policy, same class of problem as #150).

Gate run locally: style-lint, lint, build, typecheck all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated state updates so `setState` now waits for the `state-changed` handler to finish before completing.
  * Handler failures now reliably propagate and/or get reported, preventing race conditions and inconsistent error handling.
  * `setStateSync` retains its immediate return behavior while safely capturing and logging any handler errors to avoid unhandled rejections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->