### PR TITLE
feat(mysa2mqtt): derive power from duty cycle for V2 thermostats

### DIFF
--- a/.changeset/v2-power-from-duty-cycle.md
+++ b/.changeset/v2-power-from-duty-cycle.md
@@ -1,8 +1,11 @@
 ---
 'mysa2mqtt': minor
+'mqtt2ha': minor
 'mysa-js-sdk': patch
 ---
 
-V2 thermostats can now report power. These devices have no current sensor and only report the duty cycle of their heating relay, which is why their **Current power** sensor has always been unavailable. Set the new `--heater-watts` option (`M2M_HEATER_WATTS`) to the rated wattage of the heaters each thermostat controls — for example `M2M_HEATER_WATTS="Kitchen=1500,34ab95ecff20=750"`, matching devices by name or id — and power is estimated as `duty cycle × rated wattage`. V1 thermostats measure their own current and continue to work with no configuration.
+V2 thermostats can now report power. These devices have no current sensor and only report the duty cycle of their heating relay, which is why their **Current power** sensor has always been unavailable. Set the new `--heater-watts` option (`M2M_HEATER_WATTS`) to the rated wattage of the heaters each thermostat controls — for example `M2M_HEATER_WATTS="Kitchen=1500,<device-id>=750"`, matching devices by name or id — and power is estimated as `duty cycle × rated wattage`. V1 thermostats measure their own current and continue to work with no configuration.
 
-The power sensor is now only created for devices that can actually report a value. If you have AC devices, or V2 thermostats for which you have not configured a wattage, their **Current power** entity will disappear from Home Assistant; it only ever showed as unavailable.
+The power sensor is now only created for devices that can actually report a value. If you have AC devices, or V2 thermostats for which you have not configured a wattage, their **Current power** entity is removed from Home Assistant on startup; it only ever showed as unavailable.
+
+`mqtt2ha` gains a `Discoverable.removeConfig()` method, which clears an entity's retained discovery topic so Home Assistant drops the entity. This is what makes the removal above take effect: because `writeConfig()` retains its payload, an entity published by an earlier run persists until its topic is explicitly cleared.

--- a/.changeset/v2-power-from-duty-cycle.md
+++ b/.changeset/v2-power-from-duty-cycle.md
@@ -1,0 +1,8 @@
+---
+'mysa2mqtt': minor
+'mysa-js-sdk': patch
+---
+
+V2 thermostats can now report power. These devices have no current sensor and only report the duty cycle of their heating relay, which is why their **Current power** sensor has always been unavailable. Set the new `--heater-watts` option (`M2M_HEATER_WATTS`) to the rated wattage of the heaters each thermostat controls — for example `M2M_HEATER_WATTS="Kitchen=1500,34ab95ecff20=750"`, matching devices by name or id — and power is estimated as `duty cycle × rated wattage`. V1 thermostats measure their own current and continue to work with no configuration.
+
+The power sensor is now only created for devices that can actually report a value. If you have AC devices, or V2 thermostats for which you have not configured a wattage, their **Current power** entity will disappear from Home Assistant; it only ever showed as unavailable.

--- a/packages/mqtt2ha/src/api/discoverable.ts
+++ b/packages/mqtt2ha/src/api/discoverable.ts
@@ -214,6 +214,18 @@ export class Discoverable<
   }
 
   /**
+   * Clears the entity's retained discovery configuration, causing Home Assistant to remove the entity.
+   *
+   * Use this when an entity that may have been published by a previous run should no longer exist. Because
+   * {@link writeConfig} retains its payload, simply not calling it leaves the entity in place indefinitely.
+   */
+  async removeConfig() {
+    this.logger.debug(`Removing configuration for ${this.identifier}...`);
+    await this.mqttClient.publishAsync(this.configTopic, '', { retain: true });
+    this.wroteConfiguration = false;
+  }
+
+  /**
    * Sets additional attributes for the entity
    *
    * @param attributes - Key-value pairs of attributes to set

--- a/packages/mysa-js-sdk/src/api/events/Status.ts
+++ b/packages/mysa-js-sdk/src/api/events/Status.ts
@@ -15,6 +15,6 @@ export interface Status {
   setPoint: number;
   /** Optional electrical current draw measurement in amperes */
   current?: number;
-  /** Optional heating element duty cycle as a percentage (0-100) */
+  /** Optional heating element duty cycle, as a fraction between 0.0 and 1.0 */
   dutyCycle?: number;
 }

--- a/packages/mysa-js-sdk/src/types/mqtt/out/DeviceV2Status.ts
+++ b/packages/mysa-js-sdk/src/types/mqtt/out/DeviceV2Status.ts
@@ -20,7 +20,7 @@ export interface DeviceV2Status extends MsgPayload<OutMessageType.DEVICE_V2_STAT
   body: {
     /** Ambient temperature reading from the device sensor */
     ambTemp: number;
-    /** Current duty cycle percentage of the heating element */
+    /** Current duty cycle of the heating element, as a fraction between 0.0 and 1.0 */
     dtyCycle: number;
     /** Relative humidity percentage reading from the device sensor */
     hum: number;

--- a/packages/mysa2mqtt/README.md
+++ b/packages/mysa2mqtt/README.md
@@ -155,7 +155,34 @@ take precedence over command-line defaults.
 | `-l, --log-level`         | `M2M_LOG_LEVEL`         | `info`         | Log level: `silent`, `fatal`, `error`, `warn`, `info`, `debug`, `trace` |
 | `-f, --log-format`        | `M2M_LOG_FORMAT`        | `pretty`       | Log format: `pretty`, `json`                                            |
 | `-t, --temperature-unit`  | `M2M_TEMPERATURE_UNIT`  | `C`            | Temperature unit (`C` = Celsius, `F` = Fahrenheit)                      |
+| `--heater-watts`          | `M2M_HEATER_WATTS`      | -              | Rated wattage of the heaters controlled by each thermostat, as a comma-separated list of `<device>=<watts>` pairs (see [Power reporting](#power-reporting)) |
 | `--heartbeat-file`        | `M2M_HEARTBEAT_FILE`    | -              | File touched on every message received from the Mysa cloud, for external liveness checks (e.g. a container liveness probe on its mtime) |
+
+### Power reporting
+
+V1 baseboard thermostats measure their own current draw, so their **Current power** sensor works with no extra
+configuration.
+
+**V2 thermostats (including V2 Lite) have no current sensor.** They only report the duty cycle of their heating relay,
+so power can only be estimated as `duty cycle × the rated wattage of the attached heaters`. Because that rating is a
+property of your heaters and not of the thermostat, you have to supply it:
+
+```bash
+M2M_HEATER_WATTS="Kitchen=1500,34ab95ecff20=750"
+```
+
+Each entry maps a device — by name or by device id, both case-insensitive — to the total wattage of the heaters that
+thermostat controls. You can find both in the logs at startup.
+
+A few things to be aware of:
+
+- The **Current power** sensor is only created for devices that can actually report power. V2 thermostats you have not
+  configured, and AC devices (which report neither current nor duty cycle), get no power entity at all.
+- The reported value is an estimate. The duty cycle reflects whether the relay is energized right now, so the sensor
+  swings between 0 W and the full rated wattage rather than easing between them. Over time it still integrates to a
+  reasonable energy total in Home Assistant, but instantaneous readings are coarse.
+- Do not use the thermostat's own maximum current rating here. That figure describes what the thermostat is rated to
+  switch, which is typically several times more than the heaters connected to it.
 
 ## Usage Examples
 

--- a/packages/mysa2mqtt/README.md
+++ b/packages/mysa2mqtt/README.md
@@ -22,7 +22,7 @@ home automation platforms.
 | ------------ | --------------------------------------------------------- | ----------------------------------------------------------------------- |
 | `BB-V1-X`    | Mysa Smart Thermostat for Electric Baseboard Heaters V1   | ✅ Tested and working                                                   |
 | `BB-V2-X`    | Mysa Smart Thermostat for Electric Baseboard Heaters V2   | ⚠️ Partially working, in progress                                       |
-| `BB-V2-X-L`  | Mysa Smart Thermostat LITE for Electric Baseboard Heaters | ⚠️ Partially working, in progress; does not report power consumption    |
+| `BB-V2-X-L`  | Mysa Smart Thermostat LITE for Electric Baseboard Heaters | ⚠️ Partially working, in progress; does not measure power, but can report an estimate (see [Power reporting](#power-reporting)) |
 | `unknown`    | Mysa Smart Thermostat for Electric In-Floor Heating       | ⚠️ Should work but not tested                                           |
 | `AC-V1-X`    | Mysa Smart Thermostat for Mini-Split Heat Pumps & AC      | ⚠️ Partially working, in progress; missing swing and position functions |
 
@@ -168,7 +168,7 @@ so power can only be estimated as `duty cycle × the rated wattage of the attach
 property of your heaters and not of the thermostat, you have to supply it:
 
 ```bash
-M2M_HEATER_WATTS="Kitchen=1500,34ab95ecff20=750"
+M2M_HEATER_WATTS="Kitchen=1500,<device-id>=750"
 ```
 
 Each entry maps a device — by name or by device id, both case-insensitive — to the total wattage of the heaters that

--- a/packages/mysa2mqtt/src/main.ts
+++ b/packages/mysa2mqtt/src/main.ts
@@ -150,11 +150,14 @@ async function main() {
       )
   );
 
-  heaterWatts.forEach((_watts, key) => {
-    if (!matchedHeaterWattsKeys.has(key)) {
-      rootLogger.warn(`Heater wattage was configured for '${key}', which matches no device id or name.`);
-    }
-  });
+  // The unmatched keys are device ids or names, so they are not logged: this output is routinely
+  // pasted into public issues. The count is enough to prompt a re-read of the configuration.
+  const unmatchedHeaterWattsCount = heaterWatts.size - matchedHeaterWattsKeys.size;
+  if (unmatchedHeaterWattsCount > 0) {
+    rootLogger.warn(
+      `${unmatchedHeaterWattsCount} of the ${heaterWatts.size} heater wattage entries match no device id or name. Check the configured names and ids against your devices.`
+    );
+  }
 
   let startedThermostatCount = 0;
   const failedThermostats: Thermostat[] = [];

--- a/packages/mysa2mqtt/src/main.ts
+++ b/packages/mysa2mqtt/src/main.ts
@@ -25,7 +25,7 @@ SOFTWARE.
 
 import { writeFile } from 'fs/promises';
 import { MqttSettings } from 'mqtt2ha';
-import { MysaApiClient } from 'mysa-js-sdk';
+import { DeviceBase, MysaApiClient } from 'mysa-js-sdk';
 import { pino } from 'pino';
 import { PinoLogger } from './logger';
 import { options } from './options';
@@ -110,6 +110,32 @@ async function main() {
     state_prefix: options.mqttTopicPrefix
   };
 
+  const heaterWatts: Map<string, number> = options.heaterWatts ?? new Map();
+  const matchedHeaterWattsKeys = new Set<string>();
+
+  /**
+   * Resolves the configured heater wattage for a device, by id or by name.
+   *
+   * @param device - The Mysa device to resolve the wattage for.
+   * @returns The configured wattage, or undefined when the device was not configured.
+   */
+  function resolveHeaterWatts(device: DeviceBase): number | undefined {
+    for (const key of [device.Id, device.Name]) {
+      const normalizedKey = key?.toLowerCase();
+      if (normalizedKey == null) {
+        continue;
+      }
+
+      const watts = heaterWatts.get(normalizedKey);
+      if (watts != null) {
+        matchedHeaterWattsKeys.add(normalizedKey);
+        return watts;
+      }
+    }
+
+    return undefined;
+  }
+
   const thermostats = Object.entries(devices.DevicesObj).map(
     ([, device]) =>
       new Thermostat(
@@ -119,9 +145,16 @@ async function main() {
         new PinoLogger(rootLogger.child({ module: 'thermostat', deviceId: device.Id })),
         firmwares.Firmware[device.Id],
         serialNumbers.get(device.Id),
-        options.temperatureUnit
+        options.temperatureUnit,
+        resolveHeaterWatts(device)
       )
   );
+
+  heaterWatts.forEach((_watts, key) => {
+    if (!matchedHeaterWattsKeys.has(key)) {
+      rootLogger.warn(`Heater wattage was configured for '${key}', which matches no device id or name.`);
+    }
+  });
 
   let startedThermostatCount = 0;
   const failedThermostats: Thermostat[] = [];

--- a/packages/mysa2mqtt/src/options.ts
+++ b/packages/mysa2mqtt/src/options.ts
@@ -69,7 +69,7 @@ function parseRequiredInt(value: string) {
  * @param value - The value to parse.
  * @returns A map of lowercased device id or name to rated wattage.
  */
-function parseHeaterWatts(value: string) {
+function parseHeaterWatts(value: string): Map<string, number> {
   const mapping = new Map<string, number>();
 
   for (const pair of value.split(',')) {
@@ -183,7 +183,7 @@ export const options = new Command('mysa2mqtt')
   .addOption(
     new Option(
       '--heater-watts <heaterWatts>',
-      'rated wattage of the heaters controlled by each thermostat, as a comma-separated list of <device>=<watts> pairs, where <device> is a device id or name (e.g. "Kitchen=1500,34ab95ecff20=750"). Required for V2 thermostats to report power, as they do not measure current themselves'
+      'rated wattage of the heaters controlled by each thermostat, as a comma-separated list of <device>=<watts> pairs, where <device> is a device id or name (e.g. "Kitchen=1500,<device-id>=750"). Required for V2 thermostats to report power, as they do not measure current themselves'
     )
       .env('M2M_HEATER_WATTS')
       .argParser(parseHeaterWatts)

--- a/packages/mysa2mqtt/src/options.ts
+++ b/packages/mysa2mqtt/src/options.ts
@@ -63,6 +63,42 @@ function parseRequiredInt(value: string) {
   return parsedValue;
 }
 
+/**
+ * Parses a comma-separated list of `<device>=<watts>` pairs.
+ *
+ * @param value - The value to parse.
+ * @returns A map of lowercased device id or name to rated wattage.
+ */
+function parseHeaterWatts(value: string) {
+  const mapping = new Map<string, number>();
+
+  for (const pair of value.split(',')) {
+    const trimmedPair = pair.trim();
+    if (trimmedPair.length === 0) {
+      continue;
+    }
+
+    const separatorIndex = trimmedPair.lastIndexOf('=');
+    if (separatorIndex < 0) {
+      throw new InvalidArgumentError(`'${trimmedPair}' is not a <device>=<watts> pair.`);
+    }
+
+    const device = trimmedPair.slice(0, separatorIndex).trim();
+    const watts = Number(trimmedPair.slice(separatorIndex + 1).trim());
+
+    if (device.length === 0) {
+      throw new InvalidArgumentError(`'${trimmedPair}' is missing a device id or name.`);
+    }
+    if (!Number.isFinite(watts) || watts <= 0) {
+      throw new InvalidArgumentError(`'${trimmedPair}' must specify a wattage greater than zero.`);
+    }
+
+    mapping.set(device.toLowerCase(), watts);
+  }
+
+  return mapping;
+}
+
 export const version = getPackageVersion();
 
 const extraHelpText = `
@@ -142,6 +178,15 @@ export const options = new Command('mysa2mqtt')
       .env('M2M_TEMPERATURE_UNIT')
       .choices(['C', 'F'])
       .default('C')
+      .helpGroup('Configuration')
+  )
+  .addOption(
+    new Option(
+      '--heater-watts <heaterWatts>',
+      'rated wattage of the heaters controlled by each thermostat, as a comma-separated list of <device>=<watts> pairs, where <device> is a device id or name (e.g. "Kitchen=1500,34ab95ecff20=750"). Required for V2 thermostats to report power, as they do not measure current themselves'
+    )
+      .env('M2M_HEATER_WATTS')
+      .argParser(parseHeaterWatts)
       .helpGroup('Configuration')
   )
   .addOption(

--- a/packages/mysa2mqtt/src/thermostat.ts
+++ b/packages/mysa2mqtt/src/thermostat.ts
@@ -77,7 +77,7 @@ export class Thermostat {
   private readonly mqttClimate: Climate;
   private readonly mqttTemperature: Sensor;
   private readonly mqttHumidity: Sensor;
-  private readonly mqttPower: Sensor;
+  private readonly mqttPower: Sensor | undefined;
 
   private readonly mysaStatusUpdateHandler = (status: Status) => {
     void this.handleMysaStatusUpdate(status).catch((error: unknown) => {
@@ -99,7 +99,8 @@ export class Thermostat {
     private readonly logger: Logger,
     public readonly mysaDeviceFirmware?: FirmwareDevice,
     public readonly mysaDeviceSerialNumber?: string,
-    public readonly temperatureUnit?: 'C' | 'F'
+    public readonly temperatureUnit?: 'C' | 'F',
+    public readonly heaterWatts?: number
   ) {
     const is_celsius = (temperatureUnit ?? 'C') === 'C';
 
@@ -120,6 +121,13 @@ export class Thermostat {
 
     const isAC = mysaDevice.Model.startsWith('AC');
     this.deviceType = isAC ? 'AC' : 'BB';
+
+    // V2 hardware has no current sensor: its status messages carry a duty cycle but never a
+    // `Current` reading, so power can only be derived from a user-supplied heater rating. AC
+    // devices report neither. Testing for V2 rather than allowlisting V1 keeps the sensor for
+    // unrecognized models, which report `Current` natively today.
+    const isV2 = /-v2-/i.test(mysaDevice.Model);
+    const canReportPower = !isAC && (!isV2 || heaterWatts != null);
 
     this.mqttClimate = new Climate(
       {
@@ -245,22 +253,24 @@ export class Thermostat {
       }
     });
 
-    this.mqttPower = new Sensor({
-      mqtt: this.mqttSettings,
-      logger: this.logger,
-      component: {
-        component: 'sensor',
-        device: this.mqttDevice,
-        origin: this.mqttOrigin,
-        unique_id: `mysa_${mysaDevice.Id}_power`,
-        name: 'Current power',
-        device_class: 'power',
-        state_class: 'measurement',
-        unit_of_measurement: 'W',
-        suggested_display_precision: 0,
-        force_update: true
-      }
-    });
+    this.mqttPower = canReportPower
+      ? new Sensor({
+          mqtt: this.mqttSettings,
+          logger: this.logger,
+          component: {
+            component: 'sensor',
+            device: this.mqttDevice,
+            origin: this.mqttOrigin,
+            unique_id: `mysa_${mysaDevice.Id}_power`,
+            name: 'Current power',
+            device_class: 'power',
+            state_class: 'measurement',
+            unit_of_measurement: 'W',
+            suggested_display_precision: 0,
+            force_update: true
+          }
+        })
+      : undefined;
   }
 
   async start() {
@@ -295,9 +305,13 @@ export class Thermostat {
       await this.mqttHumidity.setState('state_topic', state.Humidity != null ? state.Humidity.v.toFixed(2) : 'None');
       await this.mqttHumidity.writeConfig();
 
-      // `state.Current.v` always has a non-zero value, even for thermostats that are off, so we can't use it to determine initial power state.
-      await this.mqttPower.setState('state_topic', 'None');
-      await this.mqttPower.writeConfig();
+      // Neither REST field is usable as an initial power state: `state.Current.v` always has a
+      // non-zero value, even for thermostats that are off, and `state.Duty.v` lags the realtime
+      // duty cycle badly. Publish nothing until the first status message arrives.
+      if (this.mqttPower != null) {
+        await this.mqttPower.setState('state_topic', 'None');
+        await this.mqttPower.writeConfig();
+      }
 
       this.mysaApiClient.emitter.on('statusChanged', this.mysaStatusUpdateHandler);
       this.mysaApiClient.emitter.on('stateChanged', this.mysaStateChangeHandler);
@@ -325,7 +339,7 @@ export class Thermostat {
     this.mysaApiClient.emitter.off('statusChanged', this.mysaStatusUpdateHandler);
     this.mysaApiClient.emitter.off('stateChanged', this.mysaStateChangeHandler);
 
-    await this.mqttPower.setState('state_topic', 'None');
+    await this.mqttPower?.setState('state_topic', 'None');
     await this.mqttTemperature.setState('state_topic', 'None');
     await this.mqttHumidity.setState('state_topic', 'None');
   }
@@ -406,11 +420,10 @@ export class Thermostat {
     this.mqttClimate.currentHumidity = status.humidity;
     this.mqttClimate.targetTemperature = this.mqttClimate.currentMode !== 'off' ? status.setPoint : undefined;
 
-    if (this.mysaDevice.Voltage != null && status.current != null) {
-      const watts = this.mysaDevice.Voltage * status.current;
-      await this.mqttPower.setState('state_topic', watts.toFixed(2));
-    } else {
-      await this.mqttPower.setState('state_topic', 'None');
+    if (this.mqttPower != null) {
+      const watts = this.computeWatts(status);
+      this.logger.debug('Computed power draw', { current: status.current, dutyCycle: status.dutyCycle, watts });
+      await this.mqttPower.setState('state_topic', watts != null ? watts.toFixed(2) : 'None');
     }
 
     await this.mqttTemperature.setState('state_topic', status.temperature.toFixed(2));
@@ -461,6 +474,20 @@ export class Thermostat {
         }
         break;
     }
+  }
+
+  private computeWatts(status: Status): number | undefined {
+    if (status.current != null && this.mysaDevice.Voltage != null) {
+      return this.mysaDevice.Voltage * status.current;
+    }
+
+    if (status.dutyCycle != null && this.heaterWatts != null) {
+      // The duty cycle is a 0.0-1.0 fraction of the heating element's rated output. Clamping
+      // bounds the error should some firmware ever report it on a different scale.
+      return this.heaterWatts * Math.min(Math.max(status.dutyCycle, 0), 1);
+    }
+
+    return undefined;
   }
 
   private computeCurrentAction(current?: number, dutyCycle?: number): ClimateAction {

--- a/packages/mysa2mqtt/src/thermostat.ts
+++ b/packages/mysa2mqtt/src/thermostat.ts
@@ -78,6 +78,8 @@ export class Thermostat {
   private readonly mqttTemperature: Sensor;
   private readonly mqttHumidity: Sensor;
   private readonly mqttPower: Sensor | undefined;
+  /** Set instead of {@link mqttPower} when this device cannot report power, to retire a previously published entity. */
+  private readonly mqttRetiredPower: Sensor | undefined;
 
   private readonly mysaStatusUpdateHandler = (status: Status) => {
     void this.handleMysaStatusUpdate(status).catch((error: unknown) => {
@@ -253,24 +255,28 @@ export class Thermostat {
       }
     });
 
-    this.mqttPower = canReportPower
-      ? new Sensor({
-          mqtt: this.mqttSettings,
-          logger: this.logger,
-          component: {
-            component: 'sensor',
-            device: this.mqttDevice,
-            origin: this.mqttOrigin,
-            unique_id: `mysa_${mysaDevice.Id}_power`,
-            name: 'Current power',
-            device_class: 'power',
-            state_class: 'measurement',
-            unit_of_measurement: 'W',
-            suggested_display_precision: 0,
-            force_update: true
-          }
-        })
-      : undefined;
+    const powerSensor = new Sensor({
+      mqtt: this.mqttSettings,
+      logger: this.logger,
+      component: {
+        component: 'sensor',
+        device: this.mqttDevice,
+        origin: this.mqttOrigin,
+        unique_id: `mysa_${mysaDevice.Id}_power`,
+        name: 'Current power',
+        device_class: 'power',
+        state_class: 'measurement',
+        unit_of_measurement: 'W',
+        suggested_display_precision: 0,
+        force_update: true
+      }
+    });
+
+    // The discovery config is retained, so a device that can no longer report power has to have
+    // its topic cleared explicitly — otherwise an entity published by an earlier run lingers in
+    // Home Assistant forever.
+    this.mqttPower = canReportPower ? powerSensor : undefined;
+    this.mqttRetiredPower = canReportPower ? undefined : powerSensor;
   }
 
   async start() {
@@ -312,6 +318,7 @@ export class Thermostat {
         await this.mqttPower.setState('state_topic', 'None');
         await this.mqttPower.writeConfig();
       }
+      await this.mqttRetiredPower?.removeConfig();
 
       this.mysaApiClient.emitter.on('statusChanged', this.mysaStatusUpdateHandler);
       this.mysaApiClient.emitter.on('stateChanged', this.mysaStateChangeHandler);


### PR DESCRIPTION
Fixes #9.

## Problem

The **Current power** sensor is permanently `None` on every Mysa V2 thermostat. The raw MQTT captures in the issue thread, and [mysotherm's message docs](https://github.com/dlenski/mysotherm/blob/main/mysa_messages.md), confirm why: **V2 hardware has no current sensor.** V1 status messages carry `Current` (amperes); V2 messages carry only `dtyCycle` — the instantaneous relay state, on a 0.0–1.0 scale. Since the watts calculation was `Voltage × status.current` and `current` is always `undefined` on V2, the sensor never published a value. AC devices report neither field and were in the same dead end.

## Approach

Power on V2 can only be derived as `duty cycle × rated watts`. The tempting automatic source for the rating — `MaxCurrent × Voltage` — is **wrong**: `MaxCurrent` (17.52 A) describes what the *thermostat* is rated to switch, so 240 V × 17.52 A = 4204 W, while the reporter in the thread has ~4000 W of heaters across *three* thermostats. Publishing that would feed HA energy and cost dashboards a ~3× overstatement with nothing to signal it.

So the rating is user-supplied and opt-in:

```bash
M2M_HEATER_WATTS="Kitchen=1500,34ab95ecff20=750"
```

Devices match by name or id, case-insensitively; both appear in the startup logs. V1 thermostats measure their own current and keep working with no configuration.

## Changes

| File | Change |
|---|---|
| `packages/mysa2mqtt/src/options.ts` | New `--heater-watts` / `M2M_HEATER_WATTS` option with a validating parser |
| `packages/mysa2mqtt/src/main.ts` | Resolves wattage per device; warns when entries match no device |
| `packages/mysa2mqtt/src/thermostat.ts` | `computeWatts` helper; power sensor only created for devices that can report one, and retired for those that can't |
| `packages/mqtt2ha/src/api/discoverable.ts` | New `Discoverable.removeConfig()`, which clears an entity's retained discovery topic |
| `packages/mysa-js-sdk/src/api/events/Status.ts`, `.../out/DeviceV2Status.ts` | TSDoc fix — `dutyCycle` is 0.0–1.0, not a 0–100 percentage |
| `packages/mysa2mqtt/README.md` | New "Power reporting" section; V2 Lite row of the hardware table now distinguishes measured from estimated power |

## Behavior change worth flagging

The power sensor is no longer created for AC devices or for V2 thermostats without a configured wattage. Those users will see the **Current power** entity removed from Home Assistant on startup — it only ever showed as unavailable, but it is a visible change and is called out in the changeset.

This is why `mqtt2ha` is touched. `writeConfig()` publishes with `retain: true`, so simply not constructing the sensor would have left an entity published by an earlier run sitting in the broker indefinitely — the entity would never actually have gone away. `removeConfig()` clears that retained topic, and `Thermostat` calls it for devices that cannot report power. It's a generic discovery operation, so it lives in the library rather than carrying any Mysa specifics.

## Verification

All four gates pass: `style-lint`, `lint`, `build`, `typecheck`. `--help` shows the option under Configuration; the parser rejects `Kitchen=abc`, `Kitchen`, `=500`, `Kitchen=0` and `Kitchen=-5` with distinct messages, and a valid mapping starts up cleanly.

**Not tested against real hardware** — the duty-cycle path is unexercised. It needs a live run confirming ~0 W while idle and ~rated W within ~30 s of raising the setpoint. A `debug`-level log records the raw `dutyCycle` alongside the computed watts to make that diagnosable.

The one residual risk is the duty-cycle scale. Every observed sample and mysotherm's docs say 0.0–1.0, but if some firmware reports 0–100, the clamp in `computeWatts` would pin power at the full rated wattage whenever the relay is on. The debug log would make that obvious.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--heater-watts` / `M2M_HEATER_WATTS` to estimate power for V2 thermostats using heating duty cycle × configured rated wattage (by thermostat name or id).
  - Improved MQTT-to-Home Assistant discovery cleanup by allowing retained discovery configuration to be removed.
- **Bug Fixes**
  - “Current power” is no longer created on startup when power can’t be measured or estimated (AC devices, and V2 thermostats without configured wattage).
- **Documentation**
  - Updated power-reporting guidance and clarified that duty cycle is a fractional value (`0.0`–`1.0`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
