### PR TITLE
fix(sdk): support AC-V1-X fan speed fn values from SupportedCaps (CodeNum=1117)

### DIFF
--- a/.changeset/ac-v1-fan-speed-fn-values.md
+++ b/.changeset/ac-v1-fan-speed-fn-values.md
@@ -7,3 +7,4 @@ Fix fan-speed `fn` mapping for AC-V1-X (CodeNum=1117) devices (#179).
 - Derive the send-side `fn` values from the device's reported `SupportedCaps.fanSpeeds` (positionally mapped to the canonical `[auto, low, medium, high, max]` order) instead of a hardcoded universal map. Devices that don't report `fanSpeeds` keep the previous behaviour.
 - Recognise the CodeNum=1117 canonical receive values (`fn` 2/4/6 → low/medium/high) so the current fan speed is surfaced instead of coming back `undefined`.
 - Add the `fanSpeeds` field to the `SupportedCaps` type so consumers no longer need to cast to access it.
+- Throw a new `UnsupportedFanSpeedError` when a requested fan speed is not supported by the target device (e.g. `max` on a device that only exposes auto/low/medium/high), instead of silently publishing a no-op command.

--- a/.changeset/ac-v1-fan-speed-fn-values.md
+++ b/.changeset/ac-v1-fan-speed-fn-values.md
@@ -1,0 +1,9 @@
+---
+'mysa-js-sdk': patch
+---
+
+Fix fan-speed `fn` mapping for AC-V1-X (CodeNum=1117) devices (#179).
+
+- Derive the send-side `fn` values from the device's reported `SupportedCaps.fanSpeeds` (positionally mapped to the canonical `[auto, low, medium, high, max]` order) instead of a hardcoded universal map. Devices that don't report `fanSpeeds` keep the previous behaviour.
+- Recognise the CodeNum=1117 canonical receive values (`fn` 2/4/6 → low/medium/high) so the current fan speed is surfaced instead of coming back `undefined`.
+- Add the `fanSpeeds` field to the `SupportedCaps` type so consumers no longer need to cast to access it.

--- a/packages/mysa-js-sdk/src/api/Errors.ts
+++ b/packages/mysa-js-sdk/src/api/Errors.ts
@@ -57,6 +57,27 @@ export class UnknownDeviceError extends Error {
   }
 }
 
+/** Error thrown when a requested fan speed is not supported by the target device. */
+export class UnsupportedFanSpeedError extends Error {
+  /**
+   * Creates a new UnsupportedFanSpeedError instance.
+   *
+   * @param deviceId - The id of the device the command was aimed at.
+   * @param fanSpeed - The requested fan speed that the device does not support.
+   * @param supportedFanSpeeds - The fan speeds the device does support.
+   */
+  constructor(
+    public readonly deviceId: string,
+    public readonly fanSpeed: string,
+    public readonly supportedFanSpeeds: string[]
+  ) {
+    super(
+      `Device '${deviceId}' does not support the '${fanSpeed}' fan speed. Supported fan speeds: ${supportedFanSpeeds.join(', ') || '(none)'}.`
+    );
+    this.name = 'UnsupportedFanSpeedError';
+  }
+}
+
 /** Error thrown when an MQTT publish ultimately fails after retry attempts. */
 export class MqttPublishError extends Error {
   /**

--- a/packages/mysa-js-sdk/src/api/MysaApiClient.ts
+++ b/packages/mysa-js-sdk/src/api/MysaApiClient.ts
@@ -6,7 +6,7 @@ import { ChangeDeviceState } from '@/types/mqtt/in/ChangeDeviceState';
 import { InMessageType } from '@/types/mqtt/in/InMessageType';
 import { StartPublishingDeviceStatus } from '@/types/mqtt/in/StartPublishingDeviceStatus';
 import { OutMessageType } from '@/types/mqtt/out/OutMessageType';
-import { Devices, DeviceStates, Firmwares, Homes } from '@/types/rest';
+import { DeviceBase, Devices, DeviceStates, Firmwares, Homes } from '@/types/rest';
 import { DescribeThingCommand, IoTClient } from '@aws-sdk/client-iot';
 import { fromCognitoIdentityPool } from '@aws-sdk/credential-providers';
 import { AuthenticationDetails, CognitoUser, CognitoUserPool, CognitoUserSession } from 'amazon-cognito-identity-js';
@@ -53,6 +53,52 @@ const MqttResetBaseDelay = dayjs.duration(1, 'second');
 const MqttResetMaxDelay = dayjs.duration(30, 'seconds');
 /** How long a connection must stay interrupt-free before the consecutive-reset counter is cleared. */
 const MqttStabilityWindow = dayjs.duration(60, 'seconds');
+
+/** Canonical fan-speed order, matching the positional layout of a device's `SupportedCaps.fanSpeeds`. */
+const CanonicalFanSpeedOrder: MysaFanSpeedMode[] = ['auto', 'low', 'medium', 'high', 'max'];
+
+/** Universal fan-speed `fn` mapping used when a device does not report its own `SupportedCaps.fanSpeeds`. */
+const LegacyFanSpeedSendMap: Record<MysaFanSpeedMode, number> = { auto: 1, low: 3, medium: 5, high: 7, max: 8 };
+
+/**
+ * Receive-side `fn`-to-fan-speed mapping. Includes both the legacy universal values (3/5/7) and the AC-V1-X
+ * CodeNum=1117 canonical values (2/4/6); the latter are unused by legacy devices, so there is no conflict.
+ */
+const FanSpeedReceiveMap: Record<number, MysaFanSpeedMode> = {
+  1: 'auto',
+  2: 'low', // CodeNum=1117 canonical low
+  3: 'low', // legacy
+  4: 'medium', // CodeNum=1117 canonical medium
+  5: 'medium', // legacy
+  6: 'high', // CodeNum=1117 canonical high
+  7: 'high', // legacy
+  8: 'max'
+};
+
+/**
+ * Builds the send-side fan-speed `fn` mapping for a device.
+ *
+ * When the device reports `SupportedCaps.fanSpeeds`, its values are zipped positionally with
+ * {@link CanonicalFanSpeedOrder} (e.g. `[1, 2, 4, 6]` → `{ auto: 1, low: 2, medium: 4, high: 6 }`). Otherwise the
+ * {@link LegacyFanSpeedSendMap} is used, preserving backward compatibility.
+ *
+ * @param device - The device to build the mapping for.
+ * @returns A partial map from fan-speed mode to the device-specific `fn` value.
+ */
+function buildFanSpeedSendMap(device: DeviceBase): Partial<Record<MysaFanSpeedMode, number>> {
+  const fanSpeeds = device.SupportedCaps?.fanSpeeds;
+  if (!fanSpeeds || fanSpeeds.length === 0) {
+    return LegacyFanSpeedSendMap;
+  }
+
+  const map: Partial<Record<MysaFanSpeedMode, number>> = {};
+  CanonicalFanSpeedOrder.forEach((name, index) => {
+    if (index < fanSpeeds.length) {
+      map[name] = fanSpeeds[index];
+    }
+  });
+  return map;
+}
 
 /**
  * Main client for interacting with the Mysa API and real-time device communication.
@@ -437,7 +483,7 @@ export class MysaApiClient {
 
     this._logger.debug(`Sending request to set device state for '${deviceId}'...`);
     const modeMap = { off: 1, auto: 2, heat: 3, cool: 4, fan_only: 5, dry: 6 };
-    const fanSpeedMap = { auto: 1, low: 3, medium: 5, high: 7, max: 8 };
+    const fanSpeedMap = buildFanSpeedSendMap(device);
 
     const payload = serializeMqttPayload<ChangeDeviceState>({
       msg: InMessageType.CHANGE_DEVICE_STATE,
@@ -1168,19 +1214,12 @@ export class MysaApiClient {
               5: 'fan_only',
               6: 'dry'
             };
-            const fanSpeedMap: Record<number, MysaFanSpeedMode> = {
-              1: 'auto',
-              3: 'low',
-              5: 'medium',
-              7: 'high',
-              8: 'max'
-            };
-
             this.emitter.emit('stateChanged', {
               deviceId: parsedPayload.src.ref,
               mode: parsedPayload.body.state.md ? modeMap[parsedPayload.body.state.md] : undefined,
               setPoint: parsedPayload.body.state.sp,
-              fanSpeed: parsedPayload.body.state.fn !== undefined ? fanSpeedMap[parsedPayload.body.state.fn] : undefined
+              fanSpeed:
+                parsedPayload.body.state.fn !== undefined ? FanSpeedReceiveMap[parsedPayload.body.state.fn] : undefined
             });
             break;
           }

--- a/packages/mysa-js-sdk/src/api/MysaApiClient.ts
+++ b/packages/mysa-js-sdk/src/api/MysaApiClient.ts
@@ -15,7 +15,13 @@ import { hash } from 'crypto';
 import dayjs, { Dayjs } from 'dayjs';
 import duration from 'dayjs/plugin/duration.js';
 import { customAlphabet } from 'nanoid';
-import { MqttPublishError, MysaApiError, UnauthenticatedError, UnknownDeviceError } from './Errors';
+import {
+  MqttPublishError,
+  MysaApiError,
+  UnauthenticatedError,
+  UnknownDeviceError,
+  UnsupportedFanSpeedError
+} from './Errors';
 import { Logger, VoidLogger } from './Logger';
 import { MysaApiClientEventTypes } from './MysaApiClientEventTypes';
 import { MysaApiClientOptions } from './MysaApiClientOptions';
@@ -454,6 +460,7 @@ export class MysaApiClient {
    *   unchanged).
    * @throws {@link UnauthenticatedError} When the client cannot authenticate with its credentials.
    * @throws {@link UnknownDeviceError} When the device id does not match any device on the account.
+   * @throws {@link UnsupportedFanSpeedError} When the requested fan speed is not supported by the device.
    * @throws {@link Error} When MQTT connection or command sending fails.
    */
   async setDeviceState(deviceId: string, setPoint?: number, mode?: MysaDeviceMode, fanSpeed?: MysaFanSpeedMode) {
@@ -484,6 +491,12 @@ export class MysaApiClient {
     this._logger.debug(`Sending request to set device state for '${deviceId}'...`);
     const modeMap = { off: 1, auto: 2, heat: 3, cool: 4, fan_only: 5, dry: 6 };
     const fanSpeedMap = buildFanSpeedSendMap(device);
+
+    // Reject an unsupported fan speed (e.g. 'max' on a device whose SupportedCaps.fanSpeeds only covers auto/low/
+    // medium/high) rather than silently publishing fn: undefined, which the caller would perceive as a no-op.
+    if (fanSpeed !== undefined && fanSpeedMap[fanSpeed] === undefined) {
+      throw new UnsupportedFanSpeedError(deviceId, fanSpeed, Object.keys(fanSpeedMap));
+    }
 
     const payload = serializeMqttPayload<ChangeDeviceState>({
       msg: InMessageType.CHANGE_DEVICE_STATE,

--- a/packages/mysa-js-sdk/src/types/rest/Devices.ts
+++ b/packages/mysa-js-sdk/src/types/rest/Devices.ts
@@ -35,6 +35,12 @@ export interface SupportedCaps {
   version: string;
   /** Array of supported remote control key codes */
   keys: number[];
+  /**
+   * Optional device-specific fan-speed `fn` values, ordered by canonical fan speed (`[auto, low, medium, high, max]`).
+   * E.g. `[1, 2, 4, 6]` for CodeNum=1117 devices means auto=1, low=2, medium=4, high=6. When absent, a legacy universal
+   * mapping is assumed.
+   */
+  fanSpeeds?: number[];
 }
 
 /**


### PR DESCRIPTION
Fixes #179.

## Problem

The `mysa-js-sdk` used a single hardcoded, "universal" fan-speed `fn` mapping in both directions:

- **SEND** (`setDeviceState`): `{ auto: 1, low: 3, medium: 5, high: 7, max: 8 }`
- **RECEIVE** (`_processMqttMessage`): `{ 1: 'auto', 3: 'low', 5: 'medium', 7: 'high', 8: 'max' }`

AC-V1-X thermostats (Mysa for Mini-Split) with `CodeNum=1117` use `fn` values `[1, 2, 4, 6]` for auto/low/medium/high, which breaks both paths:

- Setting "medium" sends `fn=5`; the device doesn't recognise it and silently falls back to `fn=2` (low). Fan control is effectively broken.
- The device reports `fn=2/4/6`, which the receive map has no entry for, so `fanSpeed` comes back `undefined` and the current fan speed is never surfaced.

The device already advertises the correct values in `SupportedCaps.fanSpeeds` (`[1, 2, 4, 6]`, positionally ordered as `[auto, low, medium, high]`), but the SDK ignored the field — it wasn't even declared in the TypeScript type.

## Changes

All in `packages/mysa-js-sdk`:

1. **Type** (`types/rest/Devices.ts`): add the optional `fanSpeeds?: number[]` field to `SupportedCaps`, documenting its positional semantics. Consumers no longer need `as unknown as` casts to read it.
2. **Send** (`api/MysaApiClient.ts`): new `buildFanSpeedSendMap(device)` helper derives the `fn` values positionally from `SupportedCaps.fanSpeeds` (canonical order `[auto, low, medium, high, max]`), falling back to the legacy map when the device doesn't report them.
   - CodeNum=1117 `[1,2,4,6]` → `{auto:1, low:2, medium:4, high:6}`
   - No `fanSpeeds` reported → legacy `{auto:1, low:3, medium:5, high:7, max:8}` (unchanged behaviour)
3. **Receive** (`api/MysaApiClient.ts`): extend the `fn`→name map with the CodeNum=1117 canonical values (`2→low, 4→medium, 6→high`) alongside the legacy `3/5/7`. `2/4/6` are unused by legacy devices, so there is no conflict. Also hoisted to a module-level constant (previously rebuilt on every message).
4. **Changeset**: patch release for `mysa-js-sdk`.

## Scope / coordination

SDK-only. The mysa2mqtt-side handling (fan-mode discovery, command validation, state preservation) is #121; once this ships, that PR can drop its `as unknown as { fanSpeeds?: number[] }` casts in favour of the newly-typed field.

## Testing

- `npm run build` passes end-to-end (`mqtt2ha` → `mysa-js-sdk` → `mysa2mqtt`), including DTS type generation.
- `npm run lint` and `npm run style-lint` are clean for the changed files.
- End-to-end confirmation on physical CodeNum=1117 hardware still needs a maintainer with the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AC-V1-X fan-speed `fn` handling by using each device’s supported fan-speed capabilities for sending and receiving state.
  * Ensured current fan speed is surfaced correctly instead of being `undefined` for devices using canonical `fn` values.
  * Preserved compatibility for devices that don’t report device-specific fan speeds.
* **Enhancements**
  * Exposed device-reported fan-speed capabilities via `SupportedCaps.fanSpeeds`.
  * Added `UnsupportedFanSpeedError` when requesting a fan speed a device doesn’t support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->