### PR TITLE
fix(mqtt2ha)!: use reversible encoding in cleanString to avoid colliding topics (#153)

### DIFF
--- a/.changeset/cleanstring-reversible-encoding.md
+++ b/.changeset/cleanstring-reversible-encoding.md
@@ -5,16 +5,8 @@
 
 Fix colliding MQTT discovery topics produced by `cleanString` (#153).
 
-Previously every unsupported character was replaced with a single hyphen, so distinct inputs collided
-(`cleanString('a/b') === cleanString('a b')`). Two entities whose names differed only in punctuation received the
-**same** discovery topic and silently overwrote each other in Home Assistant.
+Previously every unsupported character was replaced with a single hyphen, so distinct inputs collided (`cleanString('a/b') === cleanString('a b')`). Two entities whose names differed only in punctuation received the **same** discovery topic and silently overwrote each other in Home Assistant.
 
-`cleanString` now uses a reversible, collision-free percent-style encoding: alphanumerics and underscores pass through
-unchanged, while every other character (including a literal hyphen) is escaped as `-XX`, where `XX` is the uppercase
-hex value of each UTF-8 byte. A hyphen is used as the escape sigil instead of `%` because Home Assistant only accepts
-`[A-Za-z0-9_-]` in discovery `node_id`/`object_id` segments.
+`cleanString` now uses a reversible, collision-free percent-style encoding: alphanumerics and underscores pass through unchanged, while every other character (including a literal hyphen) is escaped as `-XX`, where `XX` is the uppercase hex value of each UTF-8 byte. A hyphen is used as the escape sigil instead of `%` because Home Assistant only accepts `[A-Za-z0-9_-]` in discovery `node_id`/`object_id` segments.
 
-**Breaking change / migration:** any topic segment derived from a device or entity name that contained characters
-outside `[A-Za-z0-9_]` will now have a different name (e.g. `Living-Room` becomes `Living-20Room`). Home Assistant
-will create new entities under the new topics. After upgrading, delete the now-orphaned MQTT devices/entities from
-Home Assistant (Settings → Devices & services → MQTT) so the stale duplicates are removed.
+**Breaking change / migration:** any topic segment derived from a device or entity name that contained characters outside `[A-Za-z0-9_]` will now have a different name (e.g. `Living-Room` becomes `Living-20Room`). Home Assistant will create new entities under the new topics. After upgrading, delete the now-orphaned MQTT devices/entities from Home Assistant (Settings → Devices & services → MQTT) so the stale duplicates are removed.

--- a/.changeset/cleanstring-reversible-encoding.md
+++ b/.changeset/cleanstring-reversible-encoding.md
@@ -1,0 +1,20 @@
+---
+'mqtt2ha': major
+'mysa2mqtt': major
+---
+
+Fix colliding MQTT discovery topics produced by `cleanString` (#153).
+
+Previously every unsupported character was replaced with a single hyphen, so distinct inputs collided
+(`cleanString('a/b') === cleanString('a b')`). Two entities whose names differed only in punctuation received the
+**same** discovery topic and silently overwrote each other in Home Assistant.
+
+`cleanString` now uses a reversible, collision-free percent-style encoding: alphanumerics and underscores pass through
+unchanged, while every other character (including a literal hyphen) is escaped as `-XX`, where `XX` is the uppercase
+hex value of each UTF-8 byte. A hyphen is used as the escape sigil instead of `%` because Home Assistant only accepts
+`[A-Za-z0-9_-]` in discovery `node_id`/`object_id` segments.
+
+**Breaking change / migration:** any topic segment derived from a device or entity name that contained characters
+outside `[A-Za-z0-9_]` will now have a different name (e.g. `Living-Room` becomes `Living-20Room`). Home Assistant
+will create new entities under the new topics. After upgrading, delete the now-orphaned MQTT devices/entities from
+Home Assistant (Settings → Devices & services → MQTT) so the stale duplicates are removed.

--- a/packages/mqtt2ha/src/lib/utils.ts
+++ b/packages/mqtt2ha/src/lib/utils.ts
@@ -44,12 +44,20 @@ SOFTWARE.
  * @returns A cleaned string containing only alphanumeric characters, underscores, and hyphens
  */
 export function cleanString(raw: string): string {
-  return raw.replace(/[^A-Za-z0-9_]/g, (char) => {
-    const bytes = new TextEncoder().encode(char);
-    let escaped = '';
-    for (let i = 0; i < bytes.length; i++) {
-      escaped += `-${bytes[i].toString(16).toUpperCase().padStart(2, '0')}`;
-    }
-    return escaped;
-  });
+  // Encode the whole string to UTF-8 up front so surrogate pairs (astral code
+  // points such as emoji) resolve correctly before escaping; matching per
+  // UTF-16 code unit would split them and collapse every astral character to
+  // the same replacement-byte sequence, reintroducing collisions.
+  const bytes = new TextEncoder().encode(raw);
+  let result = '';
+  for (let i = 0; i < bytes.length; i++) {
+    const byte = bytes[i];
+    const isSafe =
+      (byte >= 0x30 && byte <= 0x39) || // 0-9
+      (byte >= 0x41 && byte <= 0x5a) || // A-Z
+      (byte >= 0x61 && byte <= 0x7a) || // a-z
+      byte === 0x5f; // _
+    result += isSafe ? String.fromCharCode(byte) : `-${byte.toString(16).toUpperCase().padStart(2, '0')}`;
+  }
+  return result;
 }

--- a/packages/mqtt2ha/src/lib/utils.ts
+++ b/packages/mqtt2ha/src/lib/utils.ts
@@ -22,20 +22,34 @@ SOFTWARE.
 */
 
 /**
- * Returns a string that is safe to use as an MQTT topic by removing invalid characters. Replaces any character that is
- * not alphanumeric, underscore, or hyphen with a hyphen. This ensures the resulting string is valid for use in MQTT
- * topic paths.
+ * Returns a string that is safe to use as an MQTT topic and as a Home Assistant discovery `node_id`/`object_id` by
+ * escaping every character that is not alphanumeric or an underscore. This is a reversible, collision-free encoding:
+ * unsupported characters (including a literal hyphen) are percent-style escaped as `-XX`, where `XX` is the uppercase
+ * hex value of each UTF-8 byte. A hyphen is used as the escape sigil rather than `%` because Home Assistant only
+ * accepts `[A-Za-z0-9_-]` in discovery ids.
+ *
+ * Because the encoding is injective, distinct inputs always produce distinct outputs, so entities whose names differ
+ * only in punctuation no longer collide onto the same discovery topic.
  *
  * @example
  *
  * ```typescript
- * cleanString('Living Room/Temp'); // returns "Living-Room-Temp"
- * cleanString('Sensor#1'); // returns "Sensor-1"
+ * cleanString('Living Room/Temp'); // returns "Living-20Room-2FTemp"
+ * cleanString('Sensor#1'); // returns "Sensor-231"
+ * cleanString('a/b'); // returns "a-2Fb"
+ * cleanString('a b'); // returns "a-20b" (no longer collides with 'a/b')
  * ```
  *
  * @param raw - The string to be cleaned
  * @returns A cleaned string containing only alphanumeric characters, underscores, and hyphens
  */
 export function cleanString(raw: string): string {
-  return raw.replace(/[^A-Za-z0-9_-]/g, '-');
+  return raw.replace(/[^A-Za-z0-9_]/g, (char) => {
+    const bytes = new TextEncoder().encode(char);
+    let escaped = '';
+    for (let i = 0; i < bytes.length; i++) {
+      escaped += `-${bytes[i].toString(16).toUpperCase().padStart(2, '0')}`;
+    }
+    return escaped;
+  });
 }


### PR DESCRIPTION
## What changed

`cleanString` in `packages/mqtt2ha/src/lib/utils.ts` replaced every unsupported character with a single hyphen:

```ts
raw.replace(/[^A-Za-z0-9_-]/g, '-')
```

Because every disallowed character mapped to the same `-`, distinct inputs collided (`cleanString('a/b') === cleanString('a b')`). Two entities whose names differed only in punctuation received the **same** discovery topic and silently overwrote each other in Home Assistant.

It now uses an injective, reversible percent-style encoding: alphanumerics and `_` pass through unchanged, while every other character (including a literal `-`) is escaped as `-XX`, the uppercase hex of each UTF-8 byte.

## Why the `-` sigil instead of `%`

The issue suggested percent-style escaping, but Home Assistant only accepts `[A-Za-z0-9_-]` in discovery `node_id`/`object_id` segments — a literal `%` would break discovery. Using `-` as the escape sigil keeps output within HA's allowed alphabet while remaining collision-free.

## Behavior

| input | before | after |
|-------|--------|-------|
| `a/b` | `a-b` | `a-2Fb` |
| `a b` | `a-b` (collision!) | `a-20b` |
| `a-b` | `a-b` | `a-2Db` |
| `mysa_abc123_climate` | unchanged | unchanged |
| `Café` | `Caf-` | `Caf-C3-A9` |

Output always stays within `[A-Za-z0-9_-]`; already-valid identifiers are untouched.

## Breaking change / migration

Topic segments derived from device/entity names containing characters outside `[A-Za-z0-9_]` are renamed (e.g. `Living-Room` → `Living-20Room`). Home Assistant will create new entities under the new topics. After upgrading, delete the now-orphaned MQTT devices/entities (Settings → Devices & services → MQTT). This is captured in the changeset as a **major** bump for both `mqtt2ha` and `mysa2mqtt`.

## Testing

- `npm run typecheck` passes across all three packages
- `npm run lint` passes

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * MQTT discovery topic segments and Home Assistant identifiers derived from names containing punctuation or other unsupported characters now use collision-free, reversible encoding to prevent collisions.
  * After upgrading, delete orphaned MQTT devices and entities in Home Assistant whose names include characters outside letters, numbers, and underscores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->