### PR TITLE
feat(mysa2mqtt): poll device state over REST to keep HA current when real-time fails

### DIFF
--- a/.changeset/rest-state-polling.md
+++ b/.changeset/rest-state-polling.md
@@ -1,0 +1,7 @@
+---
+'mysa2mqtt': minor
+---
+
+Poll device state over REST periodically so Home Assistant stays current even when the real-time AWS IoT connection cannot be established (e.g. all-Lite fleets, whose WebSocket handshake fails with `AWS_ERROR_HTTP_WEBSOCKET_UPGRADE_FAILURE`) or is chronically unstable (e.g. INF-V1). Previously these fleets only ever received the single state snapshot taken at startup, then froze.
+
+A single account-wide poll refreshes every thermostat, so the request cost does not grow with fleet size. Configure the cadence with `--poll-interval-seconds` (`M2M_POLL_INTERVAL_SECONDS`), which defaults to 60 seconds; set it to 0 to disable, or to at least 30.

--- a/packages/mysa2mqtt/src/main.ts
+++ b/packages/mysa2mqtt/src/main.ts
@@ -201,7 +201,17 @@ function startStatePolling(client: MysaApiClient, thermostats: Thermostat[]): vo
 
   rootLogger.info(`Polling device state over REST every ${intervalSeconds}s`);
 
+  // Guard against overlapping polls: a slow getDeviceStates() must not let successive ticks stack up
+  // concurrent account-wide requests. Skip a tick while the previous poll is still pending.
+  let pollInFlight = false;
+
   setInterval(() => {
+    if (pollInFlight) {
+      rootLogger.debug('Skipping REST state poll; previous poll still in flight');
+      return;
+    }
+
+    pollInFlight = true;
     void (async () => {
       try {
         const deviceStates = await client.getDeviceStates();
@@ -212,6 +222,8 @@ function startStatePolling(client: MysaApiClient, thermostats: Thermostat[]): vo
         );
       } catch (error) {
         rootLogger.warn(error, 'Periodic REST state poll failed');
+      } finally {
+        pollInFlight = false;
       }
     })();
   }, intervalSeconds * 1000);

--- a/packages/mysa2mqtt/src/main.ts
+++ b/packages/mysa2mqtt/src/main.ts
@@ -176,6 +176,45 @@ async function main() {
   for (const thermostat of failedThermostats) {
     scheduleThermostatStartRetry(thermostat);
   }
+
+  startStatePolling(client, thermostats);
+}
+
+/**
+ * Starts the periodic REST state poll that keeps Home Assistant current independently of the real-time MQTT path.
+ *
+ * The real-time AWS IoT connection never establishes for some fleets (e.g. all-Lite accounts) and is chronically
+ * unstable for others; without this, their entities would freeze on the single snapshot taken at startup. One poll
+ * fetches the whole account's state and fans it out to every thermostat, so the request cost is independent of fleet
+ * size. Disabled when the interval is 0.
+ *
+ * @param client - Authenticated Mysa API client.
+ * @param thermostats - The thermostats to refresh.
+ */
+function startStatePolling(client: MysaApiClient, thermostats: Thermostat[]): void {
+  const intervalSeconds = options.pollIntervalSeconds;
+  if (intervalSeconds <= 0 || thermostats.length === 0) {
+    return;
+  }
+
+  const thermostatsById = new Map(thermostats.map((thermostat) => [thermostat.mysaDevice.Id, thermostat]));
+
+  rootLogger.info(`Polling device state over REST every ${intervalSeconds}s`);
+
+  setInterval(() => {
+    void (async () => {
+      try {
+        const deviceStates = await client.getDeviceStates();
+        await Promise.all(
+          Array.from(thermostatsById, ([deviceId, thermostat]) =>
+            thermostat.refreshFromRest(deviceStates.DeviceStatesObj[deviceId])
+          )
+        );
+      } catch (error) {
+        rootLogger.warn(error, 'Periodic REST state poll failed');
+      }
+    })();
+  }, intervalSeconds * 1000);
 }
 
 /** Cognito error code returned when the user pool rejects the supplied password. */

--- a/packages/mysa2mqtt/src/options.ts
+++ b/packages/mysa2mqtt/src/options.ts
@@ -64,6 +64,23 @@ function parseRequiredInt(value: string) {
 }
 
 /**
+ * Parses the REST poll interval, in seconds.
+ *
+ * A value of `0` disables polling. Any other value must be at least 30 seconds: the poll hits the account-wide state
+ * endpoint once per interval for the whole fleet, and a tighter cadence would hammer Mysa for no practical benefit.
+ *
+ * @param value - The value to parse.
+ * @returns The parsed interval in seconds.
+ */
+function parsePollInterval(value: string): number {
+  const parsedValue = parseRequiredInt(value);
+  if (parsedValue !== 0 && parsedValue < 30) {
+    throw new InvalidArgumentError('Must be 0 (disabled) or at least 30 seconds.');
+  }
+  return parsedValue;
+}
+
+/**
  * Parses a comma-separated list of `<device>=<watts>` pairs.
  *
  * @param value - The value to parse.
@@ -187,6 +204,17 @@ export const options = new Command('mysa2mqtt')
     )
       .env('M2M_HEATER_WATTS')
       .argParser(parseHeaterWatts)
+      .helpGroup('Configuration')
+  )
+  .addOption(
+    new Option(
+      '--poll-interval-seconds <pollIntervalSeconds>',
+      'how often, in seconds, to refresh device state from the Mysa REST API. This keeps Home Assistant current even ' +
+        'when the real-time connection cannot be established or is unstable. Set to 0 to disable, or to at least 30'
+    )
+      .env('M2M_POLL_INTERVAL_SECONDS')
+      .argParser(parsePollInterval)
+      .default(60)
       .helpGroup('Configuration')
   )
   .addOption(

--- a/packages/mysa2mqtt/src/options.ts
+++ b/packages/mysa2mqtt/src/options.ts
@@ -74,6 +74,11 @@ function parseRequiredInt(value: string) {
  */
 function parsePollInterval(value: string): number {
   const parsedValue = parseRequiredInt(value);
+  // parseInt tolerates decimals and trailing characters ('0.5' and '0foo' both yield 0), which would
+  // silently disable polling. Require the input to be exactly an integer before the range check.
+  if (String(parsedValue) !== value.trim()) {
+    throw new InvalidArgumentError('Must be a whole number of seconds.');
+  }
   if (parsedValue !== 0 && parsedValue < 30) {
     throw new InvalidArgumentError('Must be 0 (disabled) or at least 30 seconds.');
   }

--- a/packages/mysa2mqtt/src/thermostat.ts
+++ b/packages/mysa2mqtt/src/thermostat.ts
@@ -32,6 +32,7 @@ import {
 } from 'mqtt2ha';
 import {
   DeviceBase,
+  DeviceState,
   FirmwareDevice,
   MysaApiClient,
   MysaDeviceMode,
@@ -291,24 +292,10 @@ export class Thermostat {
       const deviceStates = await this.mysaApiClient.getDeviceStates();
       const state = deviceStates.DeviceStatesObj[this.mysaDevice.Id];
 
-      this.mqttClimate.currentTemperature = state.CorrectedTemp?.v;
-      this.mqttClimate.currentHumidity = state.Humidity?.v;
-      this.mqttClimate.currentMode =
-        MYSA_RAW_MODE_TO_DEVICE_MODE[state.TstatMode?.v as number] ?? this.mqttClimate.currentMode;
-      this.mqttClimate.currentFanMode =
-        MYSA_RAW_FAN_SPEED_TO_FAN_SPEED_MODE[state.FanSpeed?.v as number] ?? this.mqttClimate.currentFanMode;
-      this.mqttClimate.currentAction = this.computeCurrentAction(undefined, state.Duty?.v);
-      this.mqttClimate.targetTemperature = this.mqttClimate.currentMode !== 'off' ? state.SetPoint?.v : undefined;
+      await this.publishRestState(state);
 
       await this.mqttClimate.writeConfig();
-
-      await this.mqttTemperature.setState(
-        'state_topic',
-        state.CorrectedTemp != null ? state.CorrectedTemp.v.toFixed(2) : 'None'
-      );
       await this.mqttTemperature.writeConfig();
-
-      await this.mqttHumidity.setState('state_topic', state.Humidity != null ? state.Humidity.v.toFixed(2) : 'None');
       await this.mqttHumidity.writeConfig();
 
       // Neither REST field is usable as an initial power state: `state.Current.v` always has a
@@ -330,6 +317,58 @@ export class Thermostat {
       this.clearRealtimeRetry();
       throw error;
     }
+  }
+
+  /**
+   * Refreshes the published entities from a periodic REST state poll.
+   *
+   * The bridge normally tracks state through the real-time MQTT stream, but that connection never establishes for some
+   * fleets (e.g. all-Lite accounts, whose AWS IoT WebSocket handshake fails) and is chronically unstable for others.
+   * This keeps Home Assistant current in those cases: the REST `getDeviceStates` endpoint reports fresh temperature,
+   * humidity, setpoint and mode for every device type regardless of the real-time path.
+   *
+   * A no-op until the thermostat is started, and when the poll response omits this device. Power is intentionally not
+   * refreshed here — see {@link publishRestState}.
+   *
+   * @param state - This device's entry from a `getDeviceStates` response, or undefined when it was absent.
+   */
+  async refreshFromRest(state: DeviceState | undefined): Promise<void> {
+    if (!this.isStarted || state == null) {
+      return;
+    }
+
+    try {
+      await this.publishRestState(state);
+    } catch (error) {
+      this.logger.error('Failed to apply REST state poll', { error, deviceId: this.mysaDevice.Id });
+    }
+  }
+
+  /**
+   * Maps a REST device-state snapshot onto the climate, temperature and humidity entities.
+   *
+   * Shared by startup and the periodic {@link refreshFromRest} poll. It publishes entity state only; discovery config is
+   * written separately. The power sensor is deliberately left untouched: `state.Current` is non-zero even when the
+   * thermostat is off and `state.Duty` lags the real-time duty cycle badly, so power is published only from real-time
+   * status messages.
+   *
+   * @param state - This device's entry from a `getDeviceStates` response.
+   */
+  private async publishRestState(state: DeviceState): Promise<void> {
+    this.mqttClimate.currentTemperature = state.CorrectedTemp?.v;
+    this.mqttClimate.currentHumidity = state.Humidity?.v;
+    this.mqttClimate.currentMode =
+      MYSA_RAW_MODE_TO_DEVICE_MODE[state.TstatMode?.v as number] ?? this.mqttClimate.currentMode;
+    this.mqttClimate.currentFanMode =
+      MYSA_RAW_FAN_SPEED_TO_FAN_SPEED_MODE[state.FanSpeed?.v as number] ?? this.mqttClimate.currentFanMode;
+    this.mqttClimate.currentAction = this.computeCurrentAction(undefined, state.Duty?.v);
+    this.mqttClimate.targetTemperature = this.mqttClimate.currentMode !== 'off' ? state.SetPoint?.v : undefined;
+
+    await this.mqttTemperature.setState(
+      'state_topic',
+      state.CorrectedTemp != null ? state.CorrectedTemp.v.toFixed(2) : 'None'
+    );
+    await this.mqttHumidity.setState('state_topic', state.Humidity != null ? state.Humidity.v.toFixed(2) : 'None');
   }
 
   async stop() {

--- a/packages/mysa2mqtt/src/thermostat.ts
+++ b/packages/mysa2mqtt/src/thermostat.ts
@@ -292,7 +292,11 @@ export class Thermostat {
       const deviceStates = await this.mysaApiClient.getDeviceStates();
       const state = deviceStates.DeviceStatesObj[this.mysaDevice.Id];
 
-      await this.publishRestState(state);
+      // The device may be absent from the account-wide response; still register the entities so the
+      // realtime stream and REST poll can populate them later, but skip the state that would deref it.
+      if (state != null) {
+        await this.publishRestState(state);
+      }
 
       await this.mqttClimate.writeConfig();
       await this.mqttTemperature.writeConfig();


### PR DESCRIPTION
## Summary

Fixes [#125](https://github.com/bourquep/mysa2mqtt/issues/125). The bridge tracked device state solely through the real-time AWS IoT MQTT stream. That connection **never establishes for all-Lite fleets** (the WebSocket handshake fails with `AWS_ERROR_HTTP_WEBSOCKET_UPGRADE_FAILURE`) and is **chronically unstable for INF-V1**. Those fleets only ever received the single state snapshot taken at startup, then froze in Home Assistant.

This adds a periodic REST state poll that keeps Home Assistant current independently of the real-time path. REST (`getDeviceStates`) reports fresh temperature, humidity, setpoint and mode for every device type, so it fully covers the fleets where real-time is broken.

The process no longer crashes on these fleets (the retry hardening from #130 and the storm recovery from #178/#202 are already in the tree) — the remaining gap was purely stale state, which this closes.

## What changed

- **`thermostat.ts`** — extracted the REST-snapshot → MQTT mapping into a shared `publishRestState()` used by both startup and the poll, and added a public `refreshFromRest(state)` that is a no-op until started / when the device is absent from the response, with its own error guard.
- **`main.ts`** — `startStatePolling()` runs one account-wide `getDeviceStates()` per interval and fans results out to every thermostat, so request cost is independent of fleet size. Skipped when the interval is `0`.
- **`options.ts`** — new `--poll-interval-seconds` / `M2M_POLL_INTERVAL_SECONDS`, default `60`. Validation enforces `0` (disabled) or **at least 30s**.
- **Changeset** — `mysa2mqtt` minor.

## Design notes for reviewers

- **Power is intentionally left to real-time status.** REST `Current` is non-zero even when the thermostat is off and `Duty` lags badly, so the poll updates climate + temperature + humidity only — mirroring what `start()` already did for the initial snapshot.
- **Always-on, as a freshness floor under real-time.** At 60s a working real-time setpoint could briefly be overwritten by a slightly-stale REST value; users can raise the interval or set `0`. Chose this over fallback-only to avoid the complexity of reliably detecting real-time health.
- No SDK change — reuses the existing public `getDeviceStates()`.

## Validation

- `npm run build` — pass
- `npm run lint` — pass
- `npm run style-lint` — pass (my files)
- `git diff --check` — clean
- Manually verified the option: `15` → rejected, `abc` → "Must be a number", `0`/`30`/`60` → accepted; `--help` shows it under Configuration.

Per AGENTS.md, no test framework is configured, so no automated tests were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added periodic REST polling to keep thermostat state updated when the real-time connection is unavailable or unstable.
  * Added `--poll-interval-seconds` (also via `M2M_POLL_INTERVAL_SECONDS`) to control polling cadence.
  * Polling defaults to 60 seconds; supports `0` to disable and enforces a minimum of 30 seconds.

* **Bug Fixes**
  * Polling errors are logged without interrupting future refreshes.
  * Thermostat temperature, humidity, and climate settings now update from REST data, while power remains driven by real-time status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->