### PR TITLE
fix(mqtt2ha): stop publishing a meaningless state_topic for buttons (#157)

### DIFF
--- a/.changeset/button-command-only.md
+++ b/.changeset/button-command-only.md
@@ -1,0 +1,7 @@
+---
+'mqtt2ha': patch
+---
+
+Stop publishing a meaningless `state_topic` for buttons (#157).
+
+A button is command-only in the Home Assistant MQTT spec, but `Button` was passing a placeholder `state_topic` to satisfy the `Subscriber`/`Discoverable` base classes, which added a retained topic per button. `Subscriber` now supports command-only entities with no state topics (a subscriber is already interactive through its command topics), and `Button` no longer declares a state topic. Stateful subscribers (`Switch`, `Climate`) are unchanged.

--- a/packages/mqtt2ha/src/api/discoverable.ts
+++ b/packages/mqtt2ha/src/api/discoverable.ts
@@ -45,6 +45,15 @@ interface StateTopicConfiguration {
   topic: string;
 }
 
+/** Optional behavioural flags for a {@link Discoverable} entity. */
+export interface DiscoverableOptions {
+  /**
+   * Permit an entity with no state topics (a command-only entity such as a button). By default at least one state topic
+   * is required.
+   */
+  allowNoStateTopics?: boolean;
+}
+
 /**
  * Base class for Home Assistant MQTT discoverable entities. Handles the MQTT discovery protocol and provides common
  * functionality for all entity types.
@@ -104,14 +113,16 @@ export class Discoverable<
    * @param stateTopicNames - Array of state topic names
    * @param onStateChange - Callback to be called when state changes
    * @param onConnect - Optional callback to be called when MQTT connection is established
+   * @param options - Optional behavioural flags. See {@link DiscoverableOptions}.
    */
   constructor(
     settings: ComponentSettings<TComponentConfiguration>,
     stateTopicNames: Extract<keyof TStateMap, string>[],
     onStateChange: StateChangedHandler<TStateMap>,
-    onConnect?: () => void
+    onConnect?: () => void,
+    options?: DiscoverableOptions
   ) {
-    if (stateTopicNames.length === 0) {
+    if (stateTopicNames.length === 0 && !options?.allowNoStateTopics) {
       throw new Error('No state topics provided');
     }
 

--- a/packages/mqtt2ha/src/api/subscriber.ts
+++ b/packages/mqtt2ha/src/api/subscriber.ts
@@ -76,7 +76,7 @@ export class Subscriber<
    * Creates a new subscribable entity
    *
    * @param settings - The component settings including MQTT configuration
-   * @param stateTopicNames - Array of state topic names
+   * @param stateTopicNames - Array of state topic names. May be empty for a command-only entity (such as a button).
    * @param onStateChange - Callback function to handle state changes
    * @param commandTopicNames - Array of command topic names
    * @param commandCallback - Callback function to handle received commands
@@ -96,13 +96,22 @@ export class Subscriber<
     // rejection escaping these async callbacks becomes an unhandled promise
     // rejection and terminates the process under Node's default policy.
     // Catch and log instead.
-    super(settings, stateTopicNames, onStateChange, async () => {
-      try {
-        await this.subscribeToCommandTopics();
-      } catch (error) {
-        this.logger.error(`Failed to subscribe to command topics for ${this.identifier}`, error);
-      }
-    });
+    //
+    // A subscriber is interactive through its command topics, so it does not
+    // need any state topic — command-only entities pass an empty stateTopicNames.
+    super(
+      settings,
+      stateTopicNames,
+      onStateChange,
+      async () => {
+        try {
+          await this.subscribeToCommandTopics();
+        } catch (error) {
+          this.logger.error(`Failed to subscribe to command topics for ${this.identifier}`, error);
+        }
+      },
+      { allowNoStateTopics: true }
+    );
 
     this.commandCallback = commandCallback;
 

--- a/packages/mqtt2ha/src/components/button.ts
+++ b/packages/mqtt2ha/src/components/button.ts
@@ -53,6 +53,6 @@ export class Button extends Subscriber<ButtonInfo, never, CommandTopicMap> {
     settings: ComponentSettings<ButtonInfo>,
     commandCallback: (topicName: string, message: string) => Promise<void>
   ) {
-    super(settings, ['state_topic'], async () => {}, ['command_topic'], commandCallback);
+    super(settings, [], async () => {}, ['command_topic'], commandCallback);
   }
 }


### PR DESCRIPTION
Closes #157.

## What changed

A button is command-only in the Home Assistant MQTT spec, but `Button` was passing a placeholder `['state_topic']` to `Subscriber` purely to satisfy the base class, which added a retained state topic per button.

- **`Discoverable`** now accepts an optional `DiscoverableOptions` parameter with an `allowNoStateTopics` flag. The base class still throws `No state topics provided` for state-only entities that declare none; the flag suppresses that check.
- **`Subscriber`** passes `allowNoStateTopics: true`. This is safe because it already requires at least one command topic before calling `super`, so a command-only subscriber is still interactive. State topics become optional.
- **`Button`** drops the placeholder and passes `[]`, eliminating the retained state topic.

Stateful subscribers (`Switch`, `Climate`) still declare their state topics and are unchanged.

## Notes for reviewers

- The options are a named `DiscoverableOptions` interface rather than an inline object type. The repo's JSDoc and TSDoc lint rules conflict on inline object params (one demands a dotted `@param options.x`, the other forbids the dot), and named option types match the existing convention (e.g. `MysaApiClientOptions`).
- Added a `patch` changeset for `mqtt2ha`.
- All four checks pass locally: `style-lint`, `lint`, `build`, `typecheck`.

Found by CodeRabbit on #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed unnecessary MQTT state topics from Home Assistant button command entities.
  - Prevented creation of meaningless retained state topics for buttons.
  - Preserved command handling while continuing to support state topics for stateful components such as switches and climate controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->