### PR TITLE
feat: add support for in-floor heating thermostats (INF-V1-0) (#94)

### DIFF
--- a/.changeset/in-floor-heating-entities.md
+++ b/.changeset/in-floor-heating-entities.md
@@ -1,0 +1,8 @@
+---
+'mysa2mqtt': minor
+---
+
+Add in-floor heating thermostat (INF-V1-0) support (#94).
+
+- Publish a **Floor temperature** sensor for in-floor thermostats, reflecting the floor-probe reading. The ambient air temperature remains the climate's current temperature.
+- Estimate power draw for in-floor thermostats from the `--heater-watts` rating (they report a heating-relay state rather than a current draw), gating the **Current power** sensor on that configuration just like V2 thermostats.

--- a/.changeset/in-floor-heating-support.md
+++ b/.changeset/in-floor-heating-support.md
@@ -1,0 +1,8 @@
+---
+'mysa-js-sdk': minor
+---
+
+Support Mysa in-floor heating thermostats (INF-V1-0) (#94).
+
+- Parse the in-floor-specific status fields — floor-probe temperature (`flrSnsrTemp`), binary heating-relay state (`heatStat`), tracked sensor (`trackedSnsr`) and line voltage (`lineVtg`) — which share the V2 status message type (`msg: 40`). `heatStat` maps onto the emitted `dutyCycle`, and the floor-probe reading is surfaced as a new `Status.floorTemperature`.
+- Send the correct control command `type` (3) for in-floor thermostats so setpoint and mode changes take effect instead of being silently ignored.

--- a/packages/mysa-js-sdk/src/api/MysaApiClient.ts
+++ b/packages/mysa-js-sdk/src/api/MysaApiClient.ts
@@ -519,11 +519,13 @@ export class MysaApiClient {
             ? 1
             : device.Model.startsWith('AC-V1')
               ? 2
-              : device.Model.startsWith('BB-V2')
-                ? device.Model.endsWith('-L')
-                  ? 5
-                  : 4
-                : 0,
+              : device.Model.startsWith('INF-V1')
+                ? 3
+                : device.Model.startsWith('BB-V2')
+                  ? device.Model.endsWith('-L')
+                    ? 5
+                    : 4
+                  : 0,
         cmd: [
           {
             tm: -1,
@@ -1208,13 +1210,26 @@ export class MysaApiClient {
       } else if (isMsgOutPayload(parsedPayload)) {
         switch (parsedPayload.msg) {
           case OutMessageType.DEVICE_AC_STATUS:
-          case OutMessageType.DEVICE_V2_STATUS:
             this.emitter.emit('statusChanged', {
               deviceId: parsedPayload.src.ref,
               temperature: parsedPayload.body.ambTemp,
               humidity: parsedPayload.body.hum,
               setPoint: parsedPayload.body.stpt,
               dutyCycle: parsedPayload.body.dtyCycle
+            });
+            break;
+
+          case OutMessageType.DEVICE_V2_STATUS:
+            // In-floor heating thermostats (INF-V1-0) share this message type but report a binary heating-relay state
+            // (`heatStat`) instead of a fractional `dtyCycle`, plus a floor-probe temperature. `heatStat` (0 or 1) is a
+            // valid 0.0-1.0 duty fraction, so it maps straight onto `dutyCycle`.
+            this.emitter.emit('statusChanged', {
+              deviceId: parsedPayload.src.ref,
+              temperature: parsedPayload.body.ambTemp,
+              humidity: parsedPayload.body.hum,
+              setPoint: parsedPayload.body.stpt,
+              dutyCycle: parsedPayload.body.dtyCycle ?? parsedPayload.body.heatStat,
+              floorTemperature: parsedPayload.body.flrSnsrTemp
             });
             break;
 

--- a/packages/mysa-js-sdk/src/api/events/Status.ts
+++ b/packages/mysa-js-sdk/src/api/events/Status.ts
@@ -17,4 +17,6 @@ export interface Status {
   current?: number;
   /** Optional heating element duty cycle, as a fraction between 0.0 and 1.0 */
   dutyCycle?: number;
+  /** Optional floor-probe temperature reading, reported only by in-floor heating thermostats (INF-V1-0) */
+  floorTemperature?: number;
 }

--- a/packages/mysa-js-sdk/src/types/mqtt/out/DeviceV2Status.ts
+++ b/packages/mysa-js-sdk/src/types/mqtt/out/DeviceV2Status.ts
@@ -26,5 +26,19 @@ export interface DeviceV2Status extends MsgPayload<OutMessageType.DEVICE_V2_STAT
     hum: number;
     /** Current temperature setpoint setting */
     stpt: number;
+    /**
+     * Binary heating-relay state (0 = off, 1 = energized) reported by in-floor heating thermostats (INF-V1-0) in place
+     * of {@link dtyCycle}. Absent on baseboard V2 devices.
+     */
+    heatStat?: number;
+    /** Floor-probe temperature reading (°C) from in-floor heating thermostats. Absent on baseboard V2 devices. */
+    flrSnsrTemp?: number;
+    /**
+     * Which sensor the in-floor thermostat regulates against (3 = floor probe, 5 = ambient air). Absent on baseboard V2
+     * devices.
+     */
+    trackedSnsr?: number;
+    /** Line voltage (V) reported by in-floor heating thermostats. Absent on baseboard V2 devices. */
+    lineVtg?: number;
   };
 }

--- a/packages/mysa-js-sdk/src/types/mqtt/out/DeviceV2Status.ts
+++ b/packages/mysa-js-sdk/src/types/mqtt/out/DeviceV2Status.ts
@@ -20,8 +20,11 @@ export interface DeviceV2Status extends MsgPayload<OutMessageType.DEVICE_V2_STAT
   body: {
     /** Ambient temperature reading from the device sensor */
     ambTemp: number;
-    /** Current duty cycle of the heating element, as a fraction between 0.0 and 1.0 */
-    dtyCycle: number;
+    /**
+     * Current duty cycle of the heating element, as a fraction between 0.0 and 1.0. Reported by baseboard V2 devices;
+     * absent on in-floor heating thermostats (INF-V1-0), which report {@link heatStat} instead.
+     */
+    dtyCycle?: number;
     /** Relative humidity percentage reading from the device sensor */
     hum: number;
     /** Current temperature setpoint setting */

--- a/packages/mysa2mqtt/README.md
+++ b/packages/mysa2mqtt/README.md
@@ -23,7 +23,7 @@ home automation platforms.
 | `BB-V1-X`    | Mysa Smart Thermostat for Electric Baseboard Heaters V1   | ✅ Tested and working                                                   |
 | `BB-V2-X`    | Mysa Smart Thermostat for Electric Baseboard Heaters V2   | ⚠️ Partially working, in progress                                       |
 | `BB-V2-X-L`  | Mysa Smart Thermostat LITE for Electric Baseboard Heaters | ⚠️ Partially working, in progress; does not measure power, but can report an estimate (see [Power reporting](#power-reporting)) |
-| `unknown`    | Mysa Smart Thermostat for Electric In-Floor Heating       | ⚠️ Should work but not tested                                           |
+| `INF-V1-0`   | Mysa Smart Thermostat for Electric In-Floor Heating       | ⚠️ Partially working, in progress; controls and a floor-temperature sensor are supported, and power can be estimated (see [Power reporting](#power-reporting)) |
 | `AC-V1-X`    | Mysa Smart Thermostat for Mini-Split Heat Pumps & AC      | ⚠️ Partially working, in progress; missing swing and position functions |
 
 ## Disclaimer
@@ -163,9 +163,10 @@ take precedence over command-line defaults.
 V1 baseboard thermostats measure their own current draw, so their **Current power** sensor works with no extra
 configuration.
 
-**V2 thermostats (including V2 Lite) have no current sensor.** They only report the duty cycle of their heating relay,
-so power can only be estimated as `duty cycle × the rated wattage of the attached heaters`. Because that rating is a
-property of your heaters and not of the thermostat, you have to supply it:
+**V2 thermostats (including V2 Lite) and in-floor thermostats (`INF-V1-0`) have no current sensor.** They only report
+the state of their heating relay — V2 as a fractional duty cycle, in-floor as a binary on/off flag — so power can only
+be estimated as `relay state × the rated wattage of the attached heaters`. Because that rating is a property of your
+heaters and not of the thermostat, you have to supply it:
 
 ```bash
 M2M_HEATER_WATTS="Kitchen=1500,<device-id>=750"
@@ -176,8 +177,8 @@ thermostat controls. You can find both in the logs at startup.
 
 A few things to be aware of:
 
-- The **Current power** sensor is only created for devices that can actually report power. V2 thermostats you have not
-  configured, and AC devices (which report neither current nor duty cycle), get no power entity at all.
+- The **Current power** sensor is only created for devices that can actually report power. V2 and in-floor thermostats
+  you have not configured, and AC devices (which report neither current nor relay state), get no power entity at all.
 - The reported value is an estimate. The duty cycle reflects whether the relay is energized right now, so the sensor
   swings between 0 W and the full rated wattage rather than easing between them. Over time it still integrates to a
   reasonable energy total in Home Assistant, but instantaneous readings are coarse.

--- a/packages/mysa2mqtt/src/thermostat.ts
+++ b/packages/mysa2mqtt/src/thermostat.ts
@@ -77,6 +77,8 @@ export class Thermostat {
   private readonly mqttOrigin: OriginConfiguration;
   private readonly mqttClimate: Climate;
   private readonly mqttTemperature: Sensor;
+  /** Floor-probe temperature, published only for in-floor heating thermostats (INF-V1-0). */
+  private readonly mqttFloorTemperature: Sensor | undefined;
   private readonly mqttHumidity: Sensor;
   private readonly mqttPower: Sensor | undefined;
   /** Set instead of {@link mqttPower} when this device cannot report power, to retire a previously published entity. */
@@ -125,12 +127,15 @@ export class Thermostat {
     const isAC = mysaDevice.Model.startsWith('AC');
     this.deviceType = isAC ? 'AC' : 'BB';
 
-    // V2 hardware has no current sensor: its status messages carry a duty cycle but never a
-    // `Current` reading, so power can only be derived from a user-supplied heater rating. AC
-    // devices report neither. Testing for V2 rather than allowlisting V1 keeps the sensor for
-    // unrecognized models, which report `Current` natively today.
+    // V2 and in-floor hardware have no current sensor: their status messages carry a duty cycle
+    // (in-floor reports a binary `heatStat` relay flag instead) but never a `Current` reading, so
+    // power can only be derived from a user-supplied heater rating. AC devices report neither.
+    // Testing for these families rather than allowlisting V1 keeps the sensor for unrecognized
+    // models, which report `Current` natively today.
     const isV2 = /-v2-/i.test(mysaDevice.Model);
-    const canReportPower = !isAC && (!isV2 || heaterWatts != null);
+    const isInFloor = /^INF-/i.test(mysaDevice.Model);
+    const needsHeaterWatts = isV2 || isInFloor;
+    const canReportPower = !isAC && (!needsHeaterWatts || heaterWatts != null);
 
     this.mqttClimate = new Climate(
       {
@@ -239,6 +244,27 @@ export class Thermostat {
       }
     });
 
+    // In-floor thermostats report a floor-probe temperature alongside the ambient air reading. The
+    // ambient reading remains the climate's current temperature; the floor probe gets its own sensor.
+    this.mqttFloorTemperature = isInFloor
+      ? new Sensor({
+          mqtt: this.mqttSettings,
+          logger: this.logger,
+          component: {
+            component: 'sensor',
+            device: this.mqttDevice,
+            origin: this.mqttOrigin,
+            unique_id: `mysa_${mysaDevice.Id}_floor_temperature`,
+            name: 'Floor temperature',
+            device_class: 'temperature',
+            state_class: 'measurement',
+            unit_of_measurement: '°C',
+            suggested_display_precision: is_celsius ? 0.1 : 0.0,
+            force_update: true
+          }
+        })
+      : undefined;
+
     this.mqttHumidity = new Sensor({
       mqtt: this.mqttSettings,
       logger: this.logger,
@@ -300,6 +326,7 @@ export class Thermostat {
 
       await this.mqttClimate.writeConfig();
       await this.mqttTemperature.writeConfig();
+      await this.mqttFloorTemperature?.writeConfig();
       await this.mqttHumidity.writeConfig();
 
       // Neither REST field is usable as an initial power state: `state.Current.v` always has a
@@ -391,6 +418,7 @@ export class Thermostat {
 
     await this.mqttPower?.setState('state_topic', 'None');
     await this.mqttTemperature.setState('state_topic', 'None');
+    await this.mqttFloorTemperature?.setState('state_topic', 'None');
     await this.mqttHumidity.setState('state_topic', 'None');
   }
 
@@ -477,6 +505,9 @@ export class Thermostat {
     }
 
     await this.mqttTemperature.setState('state_topic', status.temperature.toFixed(2));
+    if (status.floorTemperature != null) {
+      await this.mqttFloorTemperature?.setState('state_topic', status.floorTemperature.toFixed(2));
+    }
     await this.mqttHumidity.setState('state_topic', status.humidity.toFixed(2));
   }
 


### PR DESCRIPTION
Closes #94.

## Problem

Mysa in-floor heating units (`INF-V1-0`) showed up in Home Assistant with working temperature and humidity, but:

- **Controls did nothing** — setpoint and mode changes were silently ignored by the device.
- **Power stayed `None`** — never populated.
- **Floor temperature was not exposed**, despite the device reporting both ambient air and floor-probe readings.

Tracing each symptom:

- In-floor units send a `msg: 40` (`DEVICE_V2_STATUS`) status, already handled — hence temp/humidity worked.
- The status body uses `heatStat` (a binary heating-relay flag) instead of `dtyCycle`, so `dutyCycle` was never set and `computeWatts` returned nothing → no power.
- In `setDeviceState`, `INF-V1-0` matched none of the model prefixes and fell through to the `type: 0` fallback; the device ignores commands with the wrong `type`. The setpoint-change response captured in the issue shows `"type":3`.
- The body also carries `flrSnsrTemp` / `trackedSnsr`, which were dropped.

## Changes

**SDK (`mysa-js-sdk`)**
- Add optional in-floor fields to `DeviceV2Status.body`: `heatStat`, `flrSnsrTemp`, `trackedSnsr`, `lineVtg`.
- Add `Status.floorTemperature`.
- Split the `DEVICE_V2_STATUS` handler out from the AC case: map `heatStat → dutyCycle` (fixes power) and surface `flrSnsrTemp → floorTemperature`.
- Send control command `type: 3` for `INF-V1` (fixes controls).

**Bridge (`mysa2mqtt`)**
- Publish a new **Floor temperature** sensor for in-floor units; ambient air remains the climate's current temperature.
- Estimate power from `--heater-watts` (they report relay state, not current) and gate the **Current power** entity on that config, exactly like V2.

**Docs & release**
- README: correct the in-floor hardware row (`unknown` → `INF-V1-0`) and extend the Power reporting section.
- Changesets: `mysa-js-sdk` minor, `mysa2mqtt` minor.

## Reviewer note

The control command **`type: 3`** is inferred from the setpoint-change response in the issue (`"type":3`) and has not been confirmed against real `INF-V1-0` hardware. If the device still ignores commands, that value is the thing to adjust. Everything else (floor temp, power estimate, ambient temp/humidity) is verifiable from the realtime status stream with `--heater-watts` set.

## Verification

`npm run style-lint && npm run lint && npm run build && npm run typecheck` all pass, and `node packages/mysa2mqtt/dist/main.js --help` loads. No test framework exists in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Mysa in-floor heating thermostats (INF-V1-0).
  * Added a floor temperature sensor (while keeping climate readings based on ambient air temperature).
  * Added current power estimation using configured heater wattage and relay state.

* **Bug Fixes**
  * Improved thermostat setpoint and mode control for in-floor devices.

* **Documentation**
  * Updated supported hardware and clarified power-reporting/current sensor behavior for in-floor and V2 thermostats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->