### PR TITLE
feat: add mysa2mqtt-capture tool for shadow-protocol reverse engineering

### DIFF
--- a/.changeset/shadow-topic-capture.md
+++ b/.changeset/shadow-topic-capture.md
@@ -1,0 +1,8 @@
+---
+'mysa-js-sdk': minor
+'mysa2mqtt': minor
+---
+
+Add a `mysa2mqtt-capture` tool (and the underlying `MysaApiClient.startRawTopicCapture()` SDK method) to record the raw AWS IoT Device Shadow traffic of unsupported thermostats, most notably the central-HVAC ST-V1.
+
+Unlike the real-time path, `startRawTopicCapture()` subscribes to arbitrary MQTT topic filters and relays every message verbatim (full topic + decoded payload) with no parsing, re-subscribing across reconnects. The `mysa2mqtt-capture` command uses it to dump a device's REST metadata and passively record every shadow message to a file, providing the raw material needed to implement support for a new device family. Run `npm run capture -w mysa2mqtt -- --help` for usage.

--- a/packages/mysa-js-sdk/src/api/MysaApiClient.ts
+++ b/packages/mysa-js-sdk/src/api/MysaApiClient.ts
@@ -1131,9 +1131,14 @@ export class MysaApiClient {
     const decoder = new TextDecoder('utf-8');
     for (const [filter, handler] of Array.from(this._rawTopicCaptures.entries())) {
       this._logger.debug(`Re-subscribing to raw topic filter '${filter}'`);
-      await connection.subscribe(filter, mqtt.QoS.AtLeastOnce, (topic, payload) => {
-        handler(topic, decoder.decode(payload));
-      });
+      try {
+        await connection.subscribe(filter, mqtt.QoS.AtLeastOnce, (topic, payload) => {
+          handler(topic, decoder.decode(payload));
+        });
+      } catch (error) {
+        // One rejected filter must not abort the remaining resubscriptions (matches startRawTopicCapture).
+        this._logger.warn(`Failed to re-subscribe to raw topic filter '${filter}'`, error);
+      }
     }
   }
 

--- a/packages/mysa-js-sdk/src/api/MysaApiClient.ts
+++ b/packages/mysa-js-sdk/src/api/MysaApiClient.ts
@@ -179,6 +179,12 @@ export class MysaApiClient {
   /** The device IDs that are currently being updated in real-time, mapped to their respective timeouts. */
   private _realtimeDeviceIds: Map<string, NodeJS.Timeout> = new Map();
 
+  /**
+   * Raw topic filters registered via {@link startRawTopicCapture}, mapped to their message handlers. Re-subscribed on
+   * every reconnect so a debug capture survives connection resets.
+   */
+  private _rawTopicCaptures: Map<string, (topic: string, payload: string) => void> = new Map();
+
   /** The cached devices object, if any. */
   private _cachedDevices?: Devices;
 
@@ -648,6 +654,55 @@ export class MysaApiClient {
   }
 
   /**
+   * Subscribes to raw MQTT topic filters and relays every message verbatim.
+   *
+   * Unlike {@link startRealtimeUpdates}, this performs no parsing, emits no typed events and sends no "start
+   * publishing" request to the device — it simply forwards the full message topic and the decoded UTF-8 payload of
+   * everything that arrives on the given filters. It exists to reverse-engineer device families the SDK does not model
+   * yet, most notably the AWS IoT Device Shadow protocol used by the central-HVAC ST-V1 thermostats, where both the
+   * topic (which shadow, and `accepted`/`rejected`/`delta`/`documents`) and the raw JSON body carry the information a
+   * new implementation needs.
+   *
+   * The capture is passive: the device only publishes to its shadow topics when something drives a change (the Mysa
+   * mobile app, a schedule, or the device itself), so exercise the thermostat while a capture is running.
+   *
+   * Registered filters are re-subscribed automatically after a reconnect.
+   *
+   * @param topicFilters - MQTT topic filters to subscribe to. Wildcards (`+`, `#`) are allowed, subject to the AWS IoT
+   *   policy attached to the account's Cognito identity — a filter the policy forbids resolves with a non-zero
+   *   `error_code`, which is logged rather than thrown so the remaining filters still subscribe.
+   * @param handler - Invoked with the full message topic and the decoded UTF-8 payload for every message received.
+   * @throws {@link Error} When the MQTT connection cannot be established.
+   */
+  async startRawTopicCapture(
+    topicFilters: string[],
+    handler: (topic: string, payload: string) => void
+  ): Promise<void> {
+    this._logger.info(`Starting raw topic capture for ${topicFilters.length} filter(s)`);
+
+    const connection = await this._getMqttConnection();
+    const decoder = new TextDecoder('utf-8');
+
+    for (const filter of topicFilters) {
+      this._rawTopicCaptures.set(filter, handler);
+      this._logger.debug(`Subscribing to raw topic filter '${filter}'...`);
+      try {
+        const result = await connection.subscribe(filter, mqtt.QoS.AtLeastOnce, (topic, payload) => {
+          handler(topic, decoder.decode(payload));
+        });
+        this._logger.debug(
+          `Raw subscribe to '${filter}' granted (topic='${result.topic}', qos=${result.qos}, ` +
+            `error_code=${result.error_code ?? 0})`
+        );
+      } catch (error) {
+        // A rejected filter (e.g. denied by the IoT policy) must not abort the whole capture: keep the
+        // registration so a reconnect retries it, and let the remaining filters subscribe.
+        this._logger.warn(`Failed to subscribe to raw topic filter '${filter}'`, error);
+      }
+    }
+  }
+
+  /**
    * Ensures a valid, non-expired session is available.
    *
    * This method checks if the current session is valid and not expired. If the session is expired, it automatically
@@ -1068,6 +1123,16 @@ export class MysaApiClient {
       this._logger.debug(`Re-subscribing to ${topic}`);
       await connection.subscribe(topic, mqtt.QoS.AtLeastOnce, (_topic, payload) => {
         this._processMqttMessage(payload);
+      });
+    }
+
+    // Restore any raw debug-capture subscriptions (see startRawTopicCapture) so a capture keeps
+    // flowing across reconnects.
+    const decoder = new TextDecoder('utf-8');
+    for (const [filter, handler] of Array.from(this._rawTopicCaptures.entries())) {
+      this._logger.debug(`Re-subscribing to raw topic filter '${filter}'`);
+      await connection.subscribe(filter, mqtt.QoS.AtLeastOnce, (topic, payload) => {
+        handler(topic, decoder.decode(payload));
       });
     }
   }

--- a/packages/mysa2mqtt/README.md
+++ b/packages/mysa2mqtt/README.md
@@ -438,9 +438,10 @@ Run it from a clone of the repository (no build step needed):
 git clone https://github.com/bourquep/mysa2mqtt
 cd mysa2mqtt
 npm ci
+# Pass the password via the environment so it stays out of your shell history and the process list.
+export M2M_MYSA_PASSWORD='your-password'
 npm run capture -w mysa2mqtt -- \
   --mysa-username you@example.com \
-  --mysa-password 'your-password' \
   --output mysa-capture.txt
 ```
 

--- a/packages/mysa2mqtt/README.md
+++ b/packages/mysa2mqtt/README.md
@@ -417,6 +417,53 @@ Then run:
 docker-compose up -d
 ```
 
+## Capturing data for a new thermostat type
+
+Supporting a new Mysa model means knowing exactly how it talks to the cloud. The baseboard and AC thermostats use a
+custom `/v1/dev/{id}/...` MQTT protocol, but the central-HVAC **ST-V1** thermostats use a completely different one — AWS
+IoT Device Shadows (`$aws/things/{id}/shadow/...`) — which mysa2mqtt does not model yet. Implementing it requires seeing
+the real messages the device reports and the app sends.
+
+The `mysa2mqtt-capture` tool gathers exactly that. It logs in to your Mysa account, dumps the REST metadata for the
+target device(s), then **passively records every shadow message** to a file until you stop it. It needs no MQTT broker —
+it only reads from Mysa.
+
+> [!NOTE]
+> The capture is passive: a device only publishes to its shadow when something changes it. You must exercise the
+> thermostat from the Mysa mobile app while the capture runs, otherwise nothing is recorded.
+
+Run it from a clone of the repository (no build step needed):
+
+```bash
+git clone https://github.com/bourquep/mysa2mqtt
+cd mysa2mqtt
+npm ci
+npm run capture -w mysa2mqtt -- \
+  --mysa-username you@example.com \
+  --mysa-password 'your-password' \
+  --output mysa-capture.txt
+```
+
+By default it targets every central-HVAC (`ST-*`) device on the account. Use `--device <id-or-name>` to target a
+specific one, `--all-devices` to capture from everything, or `--log-level debug` to see the per-topic subscribe results.
+Run `npm run capture -w mysa2mqtt -- --help` for the full option list.
+
+While it runs, drive the thermostat from the Mysa app so every interaction is recorded:
+
+1. Turn the system **off**, then back **on**.
+2. Switch modes: **Heat**, **Cool**, **Auto**, **Fan-only** (whatever it offers).
+3. Change the **heat** setpoint, then the **cool** setpoint.
+4. In **Auto**, change both setpoints (and the deadband if shown).
+5. Change the **fan** mode (Auto / On / Circulate).
+6. Leave it idle a few minutes to catch periodic telemetry.
+
+Pause a few seconds between actions, then press **Ctrl+C**. Attach the resulting file to a
+[GitHub issue](https://github.com/bourquep/mysa2mqtt/issues).
+
+> [!IMPORTANT]
+> The metadata dump can contain account identifiers (`Owner`, `Home`, `AllowedUsers`, `Zone`). Review the file before
+> sharing it publicly. Authentication tokens and your password are **never** included.
+
 ## Contributing
 
 If you want to contribute to this project, please read the [CONTRIBUTING.md](../../CONTRIBUTING.md) file for guidelines.

--- a/packages/mysa2mqtt/package.json
+++ b/packages/mysa2mqtt/package.json
@@ -36,7 +36,8 @@
   ],
   "type": "module",
   "bin": {
-    "mysa2mqtt": "dist/main.js"
+    "mysa2mqtt": "dist/main.js",
+    "mysa2mqtt-capture": "dist/capture.js"
   },
   "engines": {
     "node": ">=24.15.0"
@@ -44,6 +45,7 @@
   "browser": false,
   "scripts": {
     "dev": "tsx src/main.ts",
+    "capture": "tsx src/capture.ts",
     "lint": "eslint --max-warnings 0 src/**/*.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "build": "tsup"

--- a/packages/mysa2mqtt/src/capture.ts
+++ b/packages/mysa2mqtt/src/capture.ts
@@ -43,7 +43,7 @@ SOFTWARE.
 
 import { Command, InvalidArgumentError, Option } from 'commander';
 import { configDotenv } from 'dotenv';
-import { createWriteStream, WriteStream } from 'fs';
+import { chmodSync, createWriteStream, existsSync, WriteStream } from 'fs';
 import { DeviceBase, MysaApiClient, UnauthenticatedError } from 'mysa-js-sdk';
 import { pino } from 'pino';
 import { PinoLogger } from './logger';
@@ -173,8 +173,14 @@ function selectDevices(devices: Record<string, DeviceBase>): string[] {
 /** Main entry-point. */
 async function main() {
   if (options.output) {
-    // 0o600: the dump can contain account identifiers (see the file header), so don't create it
-    // world-readable. Only applies when the file is created; an existing file keeps its own mode.
+    // The dump can contain account identifiers (see the file header), so keep the file private to the
+    // current user. `mode` only applies when createWriteStream creates the file, so an existing
+    // destination — whose mode `flags: 'w'` would otherwise preserve across the truncate — is tightened
+    // explicitly first. A chmod failure (not owned, etc.) surfaces via main()'s catch rather than
+    // silently leaving the dump world-readable.
+    if (existsSync(options.output)) {
+      chmodSync(options.output, 0o600);
+    }
     outputStream = createWriteStream(options.output, { flags: 'w', mode: 0o600 });
     // Without an error handler, an async stream failure (bad path, missing directory, permissions)
     // is emitted as an unhandled 'error' event and crashes the process.

--- a/packages/mysa2mqtt/src/capture.ts
+++ b/packages/mysa2mqtt/src/capture.ts
@@ -41,7 +41,7 @@ SOFTWARE.
  * MQTT broker and only reads from Mysa.
  */
 
-import { Command, Option } from 'commander';
+import { Command, InvalidArgumentError, Option } from 'commander';
 import { configDotenv } from 'dotenv';
 import { createWriteStream, WriteStream } from 'fs';
 import { DeviceBase, MysaApiClient, UnauthenticatedError } from 'mysa-js-sdk';
@@ -82,7 +82,15 @@ const options = new Command('mysa2mqtt-capture')
   )
   .addOption(
     new Option('--duration <seconds>', 'stop automatically after this many seconds (default: run until Ctrl+C)')
-      .argParser((v) => parseInt(v, 10))
+      .argParser((v) => {
+        const parsed = parseInt(v, 10);
+        // parseInt tolerates 'abc' (NaN), '1.5' (1) and '5foo' (5); reject anything that is not a
+        // whole, non-negative number so a bad value is reported instead of silently disabling the timer.
+        if (String(parsed) !== v.trim() || parsed < 0) {
+          throw new InvalidArgumentError('Must be a whole number of seconds (0 to run until Ctrl+C).');
+        }
+        return parsed;
+      })
       .default(0)
   )
   .addOption(
@@ -165,7 +173,14 @@ function selectDevices(devices: Record<string, DeviceBase>): string[] {
 /** Main entry-point. */
 async function main() {
   if (options.output) {
-    outputStream = createWriteStream(options.output, { flags: 'w' });
+    // 0o600: the dump can contain account identifiers (see the file header), so don't create it
+    // world-readable. Only applies when the file is created; an existing file keeps its own mode.
+    outputStream = createWriteStream(options.output, { flags: 'w', mode: 0o600 });
+    // Without an error handler, an async stream failure (bad path, missing directory, permissions)
+    // is emitted as an unhandled 'error' event and crashes the process.
+    outputStream.on('error', (error) => {
+      logger.error(error, `Failed to write to output file '${options.output}'`);
+    });
     logger.info(`Writing metadata and captured messages to '${options.output}'`);
   }
 
@@ -264,7 +279,15 @@ async function main() {
   emit('  Pause a few seconds between actions. Press Ctrl+C when done.');
   emit('==================================================================');
 
+  let stopping = false;
   const stop = (reason: string) => {
+    // process.exit(0) runs from the stream's end() callback (async), so a second SIGINT/SIGTERM
+    // arriving during the flush would otherwise re-run this and double-log / end() an ended stream.
+    if (stopping) {
+      return;
+    }
+    stopping = true;
+
     logger.info(`Stopping capture (${reason}). Captured ${messageCount} message(s) across ${seenTopics.size} topic(s).`);
     if (seenTopics.size === 0) {
       logger.warn(
@@ -293,6 +316,11 @@ async function main() {
 
 main().catch((error) => {
   logger.error(error, 'Capture failed');
-  outputStream?.end();
-  process.exit(1);
+  // Wait for the output file to finish flushing before exiting, so a failure mid-capture doesn't
+  // truncate whatever was already recorded (mirrors stop()'s callback-based shutdown).
+  if (outputStream) {
+    outputStream.end(() => process.exit(1));
+  } else {
+    process.exit(1);
+  }
 });

--- a/packages/mysa2mqtt/src/capture.ts
+++ b/packages/mysa2mqtt/src/capture.ts
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+
+/*
+mysa2mqtt
+Copyright (C) 2025 Pascal Bourque
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
+ * ---------------------------------------------------------------------------
+ * Shadow-protocol capture tool (debugging / reverse-engineering aid)
+ * ---------------------------------------------------------------------------
+ *
+ * mysa2mqtt speaks the custom `/v1/dev/{id}/out`+`/in` protocol used by the
+ * baseboard and AC thermostats. The central-HVAC ST-V1 thermostats instead use
+ * AWS IoT Device Shadows (`$aws/things/{id}/shadow/...`), which the SDK does not
+ * model yet. This standalone command logs in with a Mysa account, dumps the REST
+ * metadata for the target device(s), then passively subscribes to their shadow
+ * topics and records every raw message. Drive the thermostat from the Mysa app
+ * while it runs and the capture shows exactly what the device reports and what
+ * the app sends — the raw material needed to implement support for the device.
+ *
+ * It is intentionally separate from the main bridge (`mysa2mqtt`): it needs no
+ * MQTT broker and only reads from Mysa.
+ */
+
+import { Command, Option } from 'commander';
+import { configDotenv } from 'dotenv';
+import { createWriteStream, WriteStream } from 'fs';
+import { DeviceBase, MysaApiClient, UnauthenticatedError } from 'mysa-js-sdk';
+import { pino } from 'pino';
+import { PinoLogger } from './logger';
+
+configDotenv({ path: ['.env', '.env.local'], override: true });
+
+const options = new Command('mysa2mqtt-capture')
+  .description(
+    'Capture the raw AWS IoT Device Shadow traffic of Mysa central-HVAC (ST-V1) thermostats, to help implement ' +
+      'support for them. Logs in to Mysa, dumps the device metadata, then records every shadow message until you ' +
+      'press Ctrl+C. Drive the thermostat from the Mysa app while it runs.'
+  )
+  .addOption(
+    new Option('-u, --mysa-username <mysaUsername>', 'Mysa account username (email)')
+      .env('M2M_MYSA_USERNAME')
+      .makeOptionMandatory()
+  )
+  .addOption(
+    new Option('-p, --mysa-password <mysaPassword>', 'Mysa account password').env('M2M_MYSA_PASSWORD').makeOptionMandatory()
+  )
+  .addOption(
+    new Option(
+      '-d, --device <deviceIdOrName...>',
+      'limit capture to these device id(s) or name(s). Repeatable. Defaults to every central-HVAC (ST-*) device'
+    )
+  )
+  .addOption(new Option('--all-devices', 'capture from every device on the account, not just central-HVAC ones'))
+  .addOption(
+    new Option(
+      '-e, --extra-topic <topicFilter...>',
+      'additional raw MQTT topic filter(s) to subscribe to, on top of the per-device shadow topics. Repeatable'
+    )
+  )
+  .addOption(
+    new Option('-o, --output <file>', 'also write the metadata dump and every captured message to this file')
+  )
+  .addOption(
+    new Option('--duration <seconds>', 'stop automatically after this many seconds (default: run until Ctrl+C)')
+      .argParser((v) => parseInt(v, 10))
+      .default(0)
+  )
+  .addOption(
+    new Option('-l, --log-level <logLevel>', 'log level')
+      .choices(['silent', 'fatal', 'error', 'warn', 'info', 'debug', 'trace'])
+      .env('M2M_LOG_LEVEL')
+      .default('info')
+  )
+  .parse()
+  .opts();
+
+const logger = pino({
+  name: 'mysa2mqtt-capture',
+  level: options.logLevel,
+  transport: {
+    target: 'pino-pretty',
+    options: { colorize: true, singleLine: true, ignore: 'hostname,module,pid' }
+  }
+});
+
+/** Optional file sink for the metadata dump and captured messages. */
+let outputStream: WriteStream | undefined;
+
+/**
+ * Writes a block to the console and, when `--output` was given, to the capture file. Used for the material the OP
+ * ultimately sends back (metadata + raw messages), kept separate from the pino status log.
+ *
+ * @param text - The text to emit.
+ */
+function emit(text: string): void {
+  process.stdout.write(text + '\n');
+  outputStream?.write(text + '\n');
+}
+
+/**
+ * Logs in, turning a credential rejection into an actionable message.
+ *
+ * @param client - The client to log in.
+ */
+async function login(client: MysaApiClient): Promise<void> {
+  try {
+    await client.login();
+  } catch (error) {
+    if (error instanceof UnauthenticatedError) {
+      throw new Error(
+        'Mysa rejected the credentials. Verify that the same username and password let you sign in to the Mysa ' +
+          'mobile app, and beware of a shell or .env file mangling special characters ($, `) in the password.',
+        { cause: error }
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Selects which devices to capture from, based on the CLI options.
+ *
+ * @param devices - Every device on the account, indexed by id.
+ * @returns The device ids to capture from.
+ */
+function selectDevices(devices: Record<string, DeviceBase>): string[] {
+  const entries = Object.entries(devices);
+
+  if (options.device && options.device.length > 0) {
+    const wanted = options.device.map((d: string) => d.toLowerCase());
+    const matched = entries.filter(
+      ([id, dev]) => wanted.includes(id.toLowerCase()) || (dev.Name !== undefined && wanted.includes(dev.Name.toLowerCase()))
+    );
+    return matched.map(([id]) => id);
+  }
+
+  if (options.allDevices) {
+    return entries.map(([id]) => id);
+  }
+
+  // Default: central-HVAC thermostats. Their model ids start with `ST-` (e.g. ST-V1-0).
+  return entries.filter(([, dev]) => dev.Model?.toUpperCase().startsWith('ST-')).map(([id]) => id);
+}
+
+/** Main entry-point. */
+async function main() {
+  if (options.output) {
+    outputStream = createWriteStream(options.output, { flags: 'w' });
+    logger.info(`Writing metadata and captured messages to '${options.output}'`);
+  }
+
+  const client = new MysaApiClient(
+    { username: options.mysaUsername, password: options.mysaPassword },
+    { logger: new PinoLogger(logger.child({ module: 'mysa-js-sdk' })) }
+  );
+
+  logger.info('Logging in to Mysa...');
+  await login(client);
+
+  logger.info('Fetching devices, firmwares and states...');
+  const [devices, firmwares, states] = await Promise.all([
+    client.getDevices(),
+    client.getDeviceFirmwares(),
+    client.getDeviceStates()
+  ]);
+
+  const targetIds = selectDevices(devices.DevicesObj);
+
+  if (targetIds.length === 0) {
+    logger.error(
+      'No matching devices found. If your central-HVAC thermostat did not match the ST-* filter, re-run with ' +
+        '`--all-devices` to list every device, or target it explicitly with `--device <id-or-name>`.'
+    );
+    // Still dump every device so the correct id/model is visible.
+    emit('=== ALL DEVICES (no target matched) ===');
+    emit(JSON.stringify(devices.DevicesObj, null, 2));
+    outputStream?.end();
+    return;
+  }
+
+  emit('==================================================================');
+  emit('  Mysa central-HVAC capture');
+  emit(`  Generated: ${new Date().toISOString()}`);
+  emit('  NOTE: this dump may contain account identifiers (Owner, Home,');
+  emit('  AllowedUsers, Zone). Review before sharing publicly. Auth tokens');
+  emit('  and passwords are NEVER included.');
+  emit('==================================================================');
+
+  const topicFilters: string[] = [];
+
+  for (const id of targetIds) {
+    const device = devices.DevicesObj[id];
+    const firmware = firmwares.Firmware?.[id];
+    const state = states.DeviceStatesObj?.[id];
+
+    emit('');
+    emit(`------------------------------------------------------------------`);
+    emit(`DEVICE ${device.Name ?? '(unnamed)'} — model ${device.Model} — id ${id}`);
+    emit(`Firmware: ${firmware?.InstalledVersion ?? 'unknown'}`);
+    emit(`------------------------------------------------------------------`);
+    emit('--- device metadata (REST /devices) ---');
+    emit(JSON.stringify(device, null, 2));
+    emit('--- device state (REST /states) ---');
+    emit(JSON.stringify(state ?? null, null, 2));
+
+    // The device id doubles as the AWS IoT thing name (see MysaApiClient.getDeviceSerialNumber, which
+    // calls DescribeThing with the device id), so its shadows live under $aws/things/{id}/shadow/...
+    topicFilters.push(`$aws/things/${id}/shadow/#`);
+    // Legacy custom protocol, in case the device also emits there.
+    topicFilters.push(`/v1/dev/${id}/#`);
+  }
+
+  if (options.extraTopic) {
+    topicFilters.push(...options.extraTopic);
+  }
+
+  emit('');
+  emit('=== SUBSCRIBING TO TOPIC FILTERS ===');
+  for (const filter of topicFilters) {
+    emit(`  ${filter}`);
+  }
+
+  let messageCount = 0;
+  const seenTopics = new Set<string>();
+
+  await client.startRawTopicCapture(topicFilters, (topic, payload) => {
+    messageCount++;
+    seenTopics.add(topic);
+    emit('');
+    emit(`<<< [${new Date().toISOString()}] ${topic}`);
+    emit(payload);
+  });
+
+  emit('');
+  emit('==================================================================');
+  emit('  Capture is running. Now, in the Mysa mobile app, exercise the');
+  emit('  thermostat so every interaction is recorded:');
+  emit('    1. Turn the system OFF, then back ON.');
+  emit('    2. Switch modes: Heat, Cool, Auto, Fan-only (whatever it has).');
+  emit('    3. Change the heat setpoint, then the cool setpoint.');
+  emit('    4. In Auto, change both setpoints (and the deadband if shown).');
+  emit('    5. Change the fan mode (Auto / On / Circulate).');
+  emit('    6. Leave it idle a few minutes to catch periodic telemetry.');
+  emit('  Pause a few seconds between actions. Press Ctrl+C when done.');
+  emit('==================================================================');
+
+  const stop = (reason: string) => {
+    logger.info(`Stopping capture (${reason}). Captured ${messageCount} message(s) across ${seenTopics.size} topic(s).`);
+    if (seenTopics.size === 0) {
+      logger.warn(
+        'No shadow messages were captured. Either the thermostat was not touched during the capture, or the ' +
+          "account's AWS IoT policy does not allow subscribing to its shadow topics (check the log above for " +
+          'subscribe failures). Re-run with `--log-level debug` to see the per-filter subscribe results.'
+      );
+    }
+    emit('');
+    emit(`=== END OF CAPTURE — ${messageCount} message(s), ${seenTopics.size} distinct topic(s) ===`);
+    if (outputStream) {
+      outputStream.end(() => process.exit(0));
+    } else {
+      process.exit(0);
+    }
+  };
+
+  process.on('SIGINT', () => stop('Ctrl+C'));
+  process.on('SIGTERM', () => stop('SIGTERM'));
+
+  if (options.duration && options.duration > 0) {
+    logger.info(`Will stop automatically after ${options.duration}s.`);
+    setTimeout(() => stop(`--duration ${options.duration}s elapsed`), options.duration * 1000);
+  }
+}
+
+main().catch((error) => {
+  logger.error(error, 'Capture failed');
+  outputStream?.end();
+  process.exit(1);
+});

--- a/packages/mysa2mqtt/tsup.config.cjs
+++ b/packages/mysa2mqtt/tsup.config.cjs
@@ -25,7 +25,7 @@ SOFTWARE.
 `;
 
 export default defineConfig({
-  entry: ['src/main.ts'],
+  entry: ['src/main.ts', 'src/capture.ts'],
   platform: 'node',
   format: ['esm'],
   clean: true,


### PR DESCRIPTION
## Why

Supporting a new Mysa model requires knowing exactly how it talks to the cloud. The central-HVAC **ST-V1** thermostats (see #111) speak the **AWS IoT Device Shadow** protocol (`$aws/things/{id}/shadow/...`), which is completely different from the custom `/v1/dev/{id}/...` protocol the SDK models today for baseboard/AC devices. Implementing it requires seeing the real messages the device reports and the app sends — but the existing real-time path only subscribes to `/v1/dev/{id}/out` and parses it into typed events, so it can't capture shadow traffic.

## What

- **`MysaApiClient.startRawTopicCapture(topicFilters, handler)`** — a new SDK primitive that subscribes to arbitrary MQTT topic filters and relays each message **verbatim** (full topic + decoded UTF-8 payload) with no parsing, no typed events, and no device-specific "start publishing" request. Registered filters are re-subscribed across reconnects (wired into `_resubscribeAll`). A subscribe rejected by the IoT policy is logged rather than thrown, so the remaining filters still subscribe.
  - Key detail: the Mysa **device id is the AWS IoT thing name** (the SDK already calls `DescribeThing` with it), so a device's shadows live under `$aws/things/{id}/shadow/#`.
- **`mysa2mqtt-capture`** — a standalone CLI (new `bin`) that logs in, dumps the target device's REST metadata (config, `SupportedCaps`, setpoint limits, mode, firmware, current state), then passively records every shadow message to a file until Ctrl+C. It needs no MQTT broker. Auto-targets `ST-*` models; supports `--device`, `--all-devices`, `--extra-topic`, `--output`, `--duration`.
- **README** section documenting the tool, the required app-driven actions, and a privacy note (the metadata dump can contain account GUIDs; tokens/passwords are never included).

## Notes

- The capture is **passive** by design — a device only publishes to its shadow when something changes it, so the operator exercises the thermostat from the Mysa app while it runs.
- Whether the account's Cognito IoT policy actually permits subscribing to `$aws/things/.../shadow/#` is unknown until tried; the tool logs each subscribe result (`--log-level debug`) and warns if zero messages arrive, so a denial surfaces immediately.

## Testing

`npm run build`, `npm run typecheck`, and `npm run lint` all pass. `mysa2mqtt-capture --help` renders the full option list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `mysa2mqtt-capture` to passively record AWS IoT Device Shadow MQTT messages (topic + decoded payload), including legacy shadow topics.
  - Supports targeting devices (including central-HVAC ST-*), optional extra topic filters, output to a file, and capturing for a set duration or until stopped.
  - Capture automatically re-subscribes after reconnects; prints per-message output plus an end summary.
  - Added an SDK method for streaming raw captured MQTT traffic to a handler.
- **Documentation**
  - Added a guide for capturing data for a new thermostat type (including ST-V1) with example commands and safety notes about metadata contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->