### PR TITLE
fix(mqtt2ha): stop JSON.parse-ing command payloads, keeping their string type (#163)

### DIFF
--- a/.changeset/command-payloads-stay-strings.md
+++ b/.changeset/command-payloads-stay-strings.md
@@ -1,0 +1,7 @@
+---
+'mqtt2ha': patch
+---
+
+Stop `JSON.parse`-ing command payloads, which changed their runtime type (#163).
+
+`Subscriber` used to `JSON.parse` each incoming command payload and fall back to the raw string, then cast the result to the command-map type. Because Home Assistant MQTT command payloads are strings, this meant `'123'` reached handlers as a `number` and `'true'` as a `boolean`, while `'ON'` stayed a `string` — the runtime type depended on the payload's content, contradicting the declared type. The raw string is now passed through unchanged, and `CommandCallback`/`Subscriber` constrain command-map values to `string`. Components that carry a JSON-encoded payload on a command topic are responsible for decoding it in their own handler.

--- a/packages/mqtt2ha/src/api/subscriber.ts
+++ b/packages/mqtt2ha/src/api/subscriber.ts
@@ -33,13 +33,16 @@ interface CommandTopicConfiguration {
 /**
  * A callback type for handling commands received via MQTT.
  *
- * @typeParam TCommandMap - A mapping of command topic names to their respective message types
+ * MQTT command payloads are always strings, so the values of `TCommandMap` are constrained to `string`. Components that
+ * receive a JSON-encoded payload on a command topic are responsible for decoding it inside their handler.
+ *
+ * @typeParam TCommandMap - A mapping of command topic names to their (always string) message payloads
  */
-export type CommandCallback<TCommandMap extends Record<string, unknown>> = <
+export type CommandCallback<TCommandMap extends Record<string, string>> = <
   TTopicName extends keyof TCommandMap & string
 >(
   topicName: TTopicName,
-  message: TCommandMap[TTopicName]
+  message: string
 ) => Promise<void>;
 
 /**
@@ -53,7 +56,7 @@ export type CommandCallback<TCommandMap extends Record<string, unknown>> = <
 export class Subscriber<
   TComponentConfiguration extends BaseComponentConfiguration,
   TStateMap extends Record<string, unknown>,
-  TCommandMap extends Record<string, unknown>
+  TCommandMap extends Record<string, string>
 > extends Discoverable<TComponentConfiguration, TStateMap> {
   /** List of MQTT topics for entity commands. */
   protected commandTopics: CommandTopicConfiguration[] = [];
@@ -144,15 +147,9 @@ export class Subscriber<
       const stringMessage = message.toString();
       this.logger.debug(`Received command message for ${this.identifier} on topic ${topic}: ${stringMessage}`);
 
-      let parsedMessage: unknown;
-
-      try {
-        parsedMessage = JSON.parse(stringMessage);
-      } catch {
-        parsedMessage = stringMessage;
-      }
-
-      await this.commandCallback(commandTopic.name, parsedMessage as TCommandMap[(typeof commandTopic)['name']]);
+      // MQTT command payloads are always strings. Pass the raw string through unchanged; any component that carries a
+      // JSON-encoded payload on a command topic decodes it inside its own handler.
+      await this.commandCallback(commandTopic.name, stringMessage);
     }
   }
 }


### PR DESCRIPTION
Fixes #163.

## What changed

`Subscriber.handleCommandMessage` used to run `JSON.parse(stringMessage)` with a raw-string fallback, then cast the result to the command-map type. Home Assistant MQTT command payloads are always strings, so this made the **runtime** type depend on the payload's content:

- `'123'` reached handlers as a `number`
- `'true'` as a `boolean`
- `'ON'` stayed a `string`

…while the cast claimed a single declared type. The typing was dishonest even though nothing was outright broken (the fallback preserved non-JSON strings).

This PR:

1. Drops the `JSON.parse`/cast — the raw string is passed through unchanged.
2. Constrains the command-map generic to `Record<string, string>` on both `CommandCallback` and `Subscriber`, and types the callback's `message` as `string`.
3. Documents that a component receiving a JSON-encoded payload on a command topic is responsible for decoding it in its own handler.

## Why it's safe

All concrete command maps (`Button`, `Switch`, `Climate`) already declare `string` values, and real handlers already treat payloads as strings — `Climate` uses `parseFloat`/string comparisons, and the `mysa2mqtt` consumer uses `message === 'OFF'`, `message === ''`, `parseFloat(message)`, etc. No component relied on parsed (number/boolean) payloads.

## Verification

- `tsc` typechecks cleanly for `mqtt2ha`. (The two pre-existing `floorTemperature` errors in `mysa2mqtt` are unrelated — confirmed by stashing this change.)
- `eslint` passes with `--max-warnings 0`.
- Changeset added (`mqtt2ha: patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MQTT command payloads are now delivered as raw strings without automatic JSON parsing.
  * Prevents values such as `"123"` and `"true"` from unexpectedly becoming numbers or booleans.

* **API Updates**
  * Command handlers now consistently receive string payloads.
  * Applications that use JSON-encoded commands must parse them within their own handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->