### PR TITLE
chore: set npm versioning-strategy to increase in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    # Bump the version range in package.json and update the resolved versions in
+    # package-lock.json.
+    versioning-strategy: 'increase'
     labels:
       - 'dependencies'
     commit-message:


### PR DESCRIPTION
## What changed

Added `versioning-strategy: 'increase'` to the npm ecosystem entry in `.github/dependabot.yml`.

## Why

Makes explicit that Dependabot updates both files on npm dependency updates:
- bumps the version range in `package.json`, and
- updates the resolved versions in `package-lock.json`.

`increase` is already the effective default for an app-type project, so this documents the intended behavior rather than changing it.

## Reviewer notes

- No behavior change expected in practice; this pins the strategy so it can't drift from Dependabot's defaults.
- The other ecosystems (docker, github-actions) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)