### PR TITLE
fix: restore fan-speed control for AC-V1-0 (CodeNum=1117) thermostats without enumerated SupportedCaps.fanSpeeds

### DIFF
--- a/.changeset/ac-v1-0-fan-control.md
+++ b/.changeset/ac-v1-0-fan-control.md
@@ -1,0 +1,18 @@
+---
+"mysa2mqtt": patch
+"mysa-js-sdk": patch
+---
+
+Fix fan-speed control for AC-V1-0 (CodeNum=1117) thermostats that don't enumerate `SupportedCaps.fanSpeeds`.
+
+These devices declare fan-speed support via `SupportedCaps.keys` (the FanSpeed ACState key, `4`) and report a live `FanSpeed` using canonical `fn` values (`1/2/4/6`), but their generic IR code set omits an explicit `SupportedCaps.fanSpeeds` list. As a result the fan was effectively uncontrollable:
+
+- `buildFanModes` (mysa2mqtt) treated "no `fanSpeeds`" as "no fan support" and advertised only `['auto']`, hiding low/medium/high in Home Assistant.
+- `buildFanSpeedSendMap` (mysa-js-sdk) fell back to the legacy `1/3/5/7` map, so a `high` command sent `fn: 7` — a value these canonical devices ignore — leaving the fan stuck at its current speed.
+
+Now:
+
+- `buildFanModes` advertises the canonical AC speeds (`auto/low/medium/high`) when a device omits `fanSpeeds` but declares fan support via `SupportedCaps.keys`.
+- `buildFanSpeedSendMap` uses the canonical `1/2/4/6` map for CodeNum=1117 devices without an explicit `fanSpeeds` list.
+
+Verified end-to-end against an AC-V1-0 unit: Home Assistant now advertises `auto/low/medium/high` and every fan command reaches the device (fan speed changes on the thermostat).

--- a/packages/mysa-js-sdk/src/api/MysaApiClient.ts
+++ b/packages/mysa-js-sdk/src/api/MysaApiClient.ts
@@ -67,6 +67,16 @@ const CanonicalFanSpeedOrder: MysaFanSpeedMode[] = ['auto', 'low', 'medium', 'hi
 const LegacyFanSpeedSendMap: Record<MysaFanSpeedMode, number> = { auto: 1, low: 3, medium: 5, high: 7, max: 8 };
 
 /**
+ * AC-V1-X (`CodeNum` 1117) canonical fan-speed `fn` mapping. These devices use `1/2/4/6` for auto/low/medium/high but
+ * frequently omit an explicit `SupportedCaps.fanSpeeds` list, so the legacy `1/3/5/7` map would send `fn` values they
+ * ignore. Used as the no-`fanSpeeds` fallback for CodeNum=1117 devices.
+ */
+const CanonicalFanSpeedSendMap: Partial<Record<MysaFanSpeedMode, number>> = { auto: 1, low: 2, medium: 4, high: 6 };
+
+/** `CodeNum` for AC-V1-X thermostats that use the canonical `1/2/4/6` fan-speed `fn` values. */
+const CANONICAL_FAN_SPEED_CODE_NUM = 1117;
+
+/**
  * Receive-side `fn`-to-fan-speed mapping. Includes both the legacy universal values (3/5/7) and the AC-V1-X
  * CodeNum=1117 canonical values (2/4/6); the latter are unused by legacy devices, so there is no conflict.
  */
@@ -85,8 +95,9 @@ const FanSpeedReceiveMap: Record<number, MysaFanSpeedMode> = {
  * Builds the send-side fan-speed `fn` mapping for a device.
  *
  * When the device reports `SupportedCaps.fanSpeeds`, its values are zipped positionally with
- * {@link CanonicalFanSpeedOrder} (e.g. `[1, 2, 4, 6]` → `{ auto: 1, low: 2, medium: 4, high: 6 }`). Otherwise the
- * {@link LegacyFanSpeedSendMap} is used, preserving backward compatibility.
+ * {@link CanonicalFanSpeedOrder} (e.g. `[1, 2, 4, 6]` → `{ auto: 1, low: 2, medium: 4, high: 6 }`). Otherwise, a
+ * CodeNum=1117 (AC-V1-X) device uses the {@link CanonicalFanSpeedSendMap} (it uses canonical `fn` values even without
+ * enumerating them), and any other device uses the {@link LegacyFanSpeedSendMap}, preserving backward compatibility.
  *
  * @param device - The device to build the mapping for.
  * @returns A partial map from fan-speed mode to the device-specific `fn` value.
@@ -94,7 +105,10 @@ const FanSpeedReceiveMap: Record<number, MysaFanSpeedMode> = {
 function buildFanSpeedSendMap(device: DeviceBase): Partial<Record<MysaFanSpeedMode, number>> {
   const fanSpeeds = device.SupportedCaps?.fanSpeeds;
   if (!fanSpeeds || fanSpeeds.length === 0) {
-    return LegacyFanSpeedSendMap;
+    // CodeNum=1117 (AC-V1-X) devices use canonical fn values (1/2/4/6) but frequently omit an explicit
+    // SupportedCaps.fanSpeeds list. The legacy map (1/3/5/7) would send fn values these devices ignore, so
+    // fall back to the canonical map for them; all other no-fanSpeeds devices keep the legacy universal map.
+    return device.CodeNum === CANONICAL_FAN_SPEED_CODE_NUM ? CanonicalFanSpeedSendMap : LegacyFanSpeedSendMap;
   }
 
   const map: Partial<Record<MysaFanSpeedMode, number>> = {};

--- a/packages/mysa2mqtt/src/thermostat.ts
+++ b/packages/mysa2mqtt/src/thermostat.ts
@@ -71,12 +71,15 @@ const MYSA_RAW_FAN_SPEED_TO_FAN_SPEED_MODE: Partial<Record<number, MysaFanSpeedM
 /**
  * The `SupportedCaps.keys` entry a device lists when it supports fan-speed control. These are raw ACState shadow keys
  * (e.g. key 3 = setpoint, key 4 = fan speed). AC-V1-0 units with a configured AC brand list key 4 and report a live
- * `FanSpeed`, yet their generic IR code set omits an enumerated `SupportedCaps.fanSpeeds` — so fan-speed support must be
- * inferred from `keys` rather than the (absent) `fanSpeeds` list.
+ * `FanSpeed`, yet their generic IR code set omits an enumerated `SupportedCaps.fanSpeeds` — so fan-speed support must
+ * be inferred from `keys` rather than the (absent) `fanSpeeds` list.
  */
 const FAN_SPEED_SUPPORTED_CAP_KEY = 4;
 
-/** Fan speeds advertised for AC devices that support fan control but don't enumerate their speeds (matches the SDK's `LegacyFanSpeedSendMap`, sans `max`). */
+/**
+ * Fan speeds advertised for AC devices that support fan control but don't enumerate their speeds (matches the SDK's
+ * `LegacyFanSpeedSendMap`, sans `max`).
+ */
 const DEFAULT_AC_FAN_MODES: MysaFanSpeedMode[] = ['auto', 'low', 'medium', 'high'];
 
 const REALTIME_RETRY_INITIAL_DELAY_MS = 30_000;
@@ -92,8 +95,8 @@ const REALTIME_RETRY_MAX_EXPONENT = Math.ceil(Math.log2(REALTIME_RETRY_MAX_DELAY
  *
  *   - No SupportedCaps at all → expose all modes (we have no data, so be permissive)
  *   - SupportedCaps present with fanSpeeds → expose exactly those speeds
- *   - SupportedCaps present, no fanSpeeds, but the FanSpeed key IS in `keys` → the device supports multi-speed control
- *       but doesn't enumerate its speeds (e.g. AC-V1-0 with a configured brand whose generic IR code set omits
+ *   - SupportedCaps present, no fanSpeeds, but the FanSpeed key IS in `keys` → the device supports multi-speed control but
+ *       doesn't enumerate its speeds (e.g. AC-V1-0 with a configured brand whose generic IR code set omits
  *       `fanSpeeds`). Advertise the canonical AC speeds — the SDK send path drives them via `LegacyFanSpeedSendMap`.
  *   - SupportedCaps present, no fanSpeeds, and no FanSpeed key → genuinely single-speed / Brand=None → expose only 'auto'
  */

--- a/packages/mysa2mqtt/src/thermostat.ts
+++ b/packages/mysa2mqtt/src/thermostat.ts
@@ -68,6 +68,17 @@ const MYSA_RAW_FAN_SPEED_TO_FAN_SPEED_MODE: Partial<Record<number, MysaFanSpeedM
   8: 'max'
 };
 
+/**
+ * The `SupportedCaps.keys` entry a device lists when it supports fan-speed control. These are raw ACState shadow keys
+ * (e.g. key 3 = setpoint, key 4 = fan speed). AC-V1-0 units with a configured AC brand list key 4 and report a live
+ * `FanSpeed`, yet their generic IR code set omits an enumerated `SupportedCaps.fanSpeeds` — so fan-speed support must be
+ * inferred from `keys` rather than the (absent) `fanSpeeds` list.
+ */
+const FAN_SPEED_SUPPORTED_CAP_KEY = 4;
+
+/** Fan speeds advertised for AC devices that support fan control but don't enumerate their speeds (matches the SDK's `LegacyFanSpeedSendMap`, sans `max`). */
+const DEFAULT_AC_FAN_MODES: MysaFanSpeedMode[] = ['auto', 'low', 'medium', 'high'];
+
 const REALTIME_RETRY_INITIAL_DELAY_MS = 30_000;
 const REALTIME_RETRY_MAX_DELAY_MS = 300_000;
 const REALTIME_RETRY_MAX_EXPONENT = Math.ceil(Math.log2(REALTIME_RETRY_MAX_DELAY_MS / REALTIME_RETRY_INITIAL_DELAY_MS));
@@ -80,10 +91,11 @@ const REALTIME_RETRY_MAX_EXPONENT = Math.ceil(Math.log2(REALTIME_RETRY_MAX_DELAY
  * @returns The supported fan speed modes, falling back to {@link FAN_SPEED_MODES} when none are reported.
  *
  *   - No SupportedCaps at all → expose all modes (we have no data, so be permissive)
- *   - SupportedCaps present but no fanSpeeds in any mode → expose only 'auto' (device's AC brand not configured or IR code
- *       set doesn't support multi-speed; e.g. AC-V1-0 with Brand=None uses a generic code set with only auto+one manual
- *       speed)
  *   - SupportedCaps present with fanSpeeds → expose exactly those speeds
+ *   - SupportedCaps present, no fanSpeeds, but the FanSpeed key IS in `keys` → the device supports multi-speed control
+ *       but doesn't enumerate its speeds (e.g. AC-V1-0 with a configured brand whose generic IR code set omits
+ *       `fanSpeeds`). Advertise the canonical AC speeds — the SDK send path drives them via `LegacyFanSpeedSendMap`.
+ *   - SupportedCaps present, no fanSpeeds, and no FanSpeed key → genuinely single-speed / Brand=None → expose only 'auto'
  */
 function buildFanModes(supportedCaps: SupportedCaps | undefined): MysaFanSpeedMode[] {
   if (!supportedCaps?.modes) {
@@ -107,8 +119,15 @@ function buildFanModes(supportedCaps: SupportedCaps | undefined): MysaFanSpeedMo
   }
 
   if (allSpeeds.size === 0) {
-    // SupportedCaps exists but has no fan speeds → device doesn't support multi-speed control
-    // (typically Brand=None / generic IR code set). Only expose 'auto'.
+    // No enumerated fanSpeeds. Distinguish two cases:
+    //   - The device still declares fan-speed support via SupportedCaps.keys (the FanSpeed ACState key) — e.g. an
+    //     AC-V1-0 with a configured brand whose generic IR code set omits `fanSpeeds`. It DOES support multi-speed
+    //     control (the SDK send path falls back to LegacyFanSpeedSendMap for it), so advertise the canonical speeds
+    //     rather than hiding them behind 'auto' only.
+    //   - Otherwise (no FanSpeed key) → genuinely single-speed / Brand=None → expose only 'auto'.
+    if (supportedCaps.keys?.includes(FAN_SPEED_SUPPORTED_CAP_KEY)) {
+      return [...DEFAULT_AC_FAN_MODES];
+    }
     return ['auto'];
   }
 


### PR DESCRIPTION
## Summary

Fan-speed control is effectively broken for **AC-V1-0 (`CodeNum` 1117)** thermostats that don't enumerate `SupportedCaps.fanSpeeds`. Home Assistant shows only `auto`, and even when a speed is forced it never reaches the device. This restores the behaviour these units had before the fan work was reworked around `SupportedCaps.fanSpeeds` (complements #121).

## Root cause

These devices **declare** fan-speed support via `SupportedCaps.keys` (the FanSpeed ACState key, `4`) and report a live `FanSpeed` using the canonical `fn` values (`1/2/4/6`), but their generic IR code set **omits** an explicit `SupportedCaps.fanSpeeds` list. Captured metadata from a real AC-V1-0:

```jsonc
"Model": "AC-V1-0",
"CodeNum": 1117,
"SupportedCaps": {
  "tempRange": [16, 31],
  "modes": { "3": {"temperatures":[…]}, "4": {"temperatures":[…]}, "6": {"temperatures":[]} },
  "keys": [1, 2, 4, 5, 7, 8, 9, 10, 11, 13, 14, 47]   // 4 = FanSpeed
}
// live state: "FanSpeed": { "v": 6 }   // canonical high
```

Two independent fallbacks then misfire:

- **`buildFanModes` (mysa2mqtt)** — no `fanSpeeds` ⇒ `allSpeeds.size === 0` ⇒ advertises `['auto']` only, hiding low/medium/high.
- **`buildFanSpeedSendMap` (mysa-js-sdk)** — no `fanSpeeds` ⇒ falls back to `LegacyFanSpeedSendMap` (`1/3/5/7`), so `high` sends `fn: 7`, which a canonical `1/2/4/6` device ignores → the fan is stuck.

## Fix

- `buildFanModes`: when `SupportedCaps` has no `fanSpeeds` **but** the FanSpeed key is present in `SupportedCaps.keys`, advertise the canonical AC speeds (`auto/low/medium/high`) instead of `auto`-only. Devices that genuinely lack the FanSpeed key still get `['auto']`.
- `buildFanSpeedSendMap`: for `CodeNum === 1117` devices without an explicit `fanSpeeds` list, use a canonical send map (`auto:1, low:2, medium:4, high:6`) instead of the legacy `1/3/5/7`.

## Verification

Built and deployed against a live AC-V1-0. HA now advertises `['auto','low','medium','high']`, and each fan command round-trips to the device (`fan_mode_state` follows `high → medium → low → high`).

## Notes

- `buildFanModes` is a private function, so I didn't add a unit test; happy to export it (or add a fixture-based test) if you'd prefer.
- The FanSpeed key constant (`4`) is inferred from the shadow layout (`key 3 = setpoint`, `key 4 = FanSpeed`); if the SDK has/should have a named constant for it, glad to switch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fan-speed control for AC-V1-0 thermostats that don’t report available fan speeds.
  * Correctly exposes Auto, Low, Medium, and High fan modes when multi-speed control is supported.
  * Fixed High fan commands being ignored on affected thermostats.
  * Preserved automatic fallback to Auto mode when multi-speed capability isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->