### PR TITLE
chore: Update copyright year to 2025-2026

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Pascal Bourque
+Copyright (c) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/LICENSE.txt
+++ b/packages/mqtt2ha/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Pascal Bourque
+Copyright (c) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/README.md
+++ b/packages/mqtt2ha/README.md
@@ -113,7 +113,7 @@ copyright notice and license text in any copy of the software or substantial por
 
 ## Copyright
 
-© 2025 Pascal Bourque
+© 2025-2026 Pascal Bourque
 
 ## Support
 

--- a/packages/mqtt2ha/src/api/discoverable.ts
+++ b/packages/mqtt2ha/src/api/discoverable.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/api/settings.ts
+++ b/packages/mqtt2ha/src/api/settings.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/api/subscriber.ts
+++ b/packages/mqtt2ha/src/api/subscriber.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/alarm_control_panel.ts
+++ b/packages/mqtt2ha/src/components/alarm_control_panel.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/binary_sensor.ts
+++ b/packages/mqtt2ha/src/components/binary_sensor.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/button.ts
+++ b/packages/mqtt2ha/src/components/button.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/camera.ts
+++ b/packages/mqtt2ha/src/components/camera.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/climate.ts
+++ b/packages/mqtt2ha/src/components/climate.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/cover.ts
+++ b/packages/mqtt2ha/src/components/cover.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/event.ts
+++ b/packages/mqtt2ha/src/components/event.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/fan.ts
+++ b/packages/mqtt2ha/src/components/fan.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/humidifier.ts
+++ b/packages/mqtt2ha/src/components/humidifier.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/image.ts
+++ b/packages/mqtt2ha/src/components/image.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/lawn_mower.ts
+++ b/packages/mqtt2ha/src/components/lawn_mower.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/light.ts
+++ b/packages/mqtt2ha/src/components/light.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/lock.ts
+++ b/packages/mqtt2ha/src/components/lock.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/number.ts
+++ b/packages/mqtt2ha/src/components/number.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/scene.ts
+++ b/packages/mqtt2ha/src/components/scene.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/select.ts
+++ b/packages/mqtt2ha/src/components/select.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/sensor.ts
+++ b/packages/mqtt2ha/src/components/sensor.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/siren.ts
+++ b/packages/mqtt2ha/src/components/siren.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/switch.ts
+++ b/packages/mqtt2ha/src/components/switch.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/text.ts
+++ b/packages/mqtt2ha/src/components/text.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/update.ts
+++ b/packages/mqtt2ha/src/components/update.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/vacuum.ts
+++ b/packages/mqtt2ha/src/components/vacuum.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/valve.ts
+++ b/packages/mqtt2ha/src/components/valve.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/components/water_heater.ts
+++ b/packages/mqtt2ha/src/components/water_heater.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/configuration/availability_configuration.ts
+++ b/packages/mqtt2ha/src/configuration/availability_configuration.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/configuration/component_configuration.ts
+++ b/packages/mqtt2ha/src/configuration/component_configuration.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/configuration/device_configuration.ts
+++ b/packages/mqtt2ha/src/configuration/device_configuration.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/index.ts
+++ b/packages/mqtt2ha/src/index.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/lib/logger.ts
+++ b/packages/mqtt2ha/src/lib/logger.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/src/lib/utils.ts
+++ b/packages/mqtt2ha/src/lib/utils.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/test-environment/example.ts
+++ b/packages/mqtt2ha/test-environment/example.ts
@@ -1,6 +1,6 @@
 /*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mqtt2ha/tsup.config.cjs
+++ b/packages/mqtt2ha/tsup.config.cjs
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup';
 
 const banner = `/*
 mqtt2ha
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mysa-js-sdk/LICENSE.txt
+++ b/packages/mysa-js-sdk/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mysa-js-sdk/tsup.config.cjs
+++ b/packages/mysa-js-sdk/tsup.config.cjs
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup';
 
 const banner = `/*
 mysa-js-sdk
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mysa2mqtt/LICENSE.txt
+++ b/packages/mysa2mqtt/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mysa2mqtt/README.md
+++ b/packages/mysa2mqtt/README.md
@@ -477,7 +477,7 @@ copyright notice and license text in any copy of the software or substantial por
 
 ## Copyright
 
-© 2025 Pascal Bourque
+© 2025-2026 Pascal Bourque
 
 ## Support
 

--- a/packages/mysa2mqtt/src/capture.ts
+++ b/packages/mysa2mqtt/src/capture.ts
@@ -2,7 +2,7 @@
 
 /*
 mysa2mqtt
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mysa2mqtt/src/commander.d.ts
+++ b/packages/mysa2mqtt/src/commander.d.ts
@@ -1,6 +1,6 @@
 /*
 mysa2mqtt
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mysa2mqtt/src/logger.ts
+++ b/packages/mysa2mqtt/src/logger.ts
@@ -1,6 +1,6 @@
 /*
 mysa2mqtt
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mysa2mqtt/src/main.ts
+++ b/packages/mysa2mqtt/src/main.ts
@@ -2,7 +2,7 @@
 
 /*
 mysa2mqtt
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mysa2mqtt/src/options.ts
+++ b/packages/mysa2mqtt/src/options.ts
@@ -1,6 +1,6 @@
 /*
 mysa2mqtt
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -124,7 +124,7 @@ function parseHeaterWatts(value: string): Map<string, number> {
 export const version = getPackageVersion();
 
 const extraHelpText = `
-Copyright (c) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 Licensed under the MIT License
 
 Source code and documentation available at: https://github.com/bourquep/mysa2mqtt

--- a/packages/mysa2mqtt/src/thermostat.ts
+++ b/packages/mysa2mqtt/src/thermostat.ts
@@ -1,6 +1,6 @@
 /*
 mysa2mqtt
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mysa2mqtt/tsup.config.cjs
+++ b/packages/mysa2mqtt/tsup.config.cjs
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup';
 
 const banner = `/*
 mysa2mqtt
-Copyright (C) 2025 Pascal Bourque
+Copyright (C) 2025-2026 Pascal Bourque
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated copyright notices across project documentation, licenses, source headers, and generated build banners to reflect 2025–2026.
* **Chores**
  * No functional, API, configuration behavior, or runtime changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->