### PR TITLE
fix(sdk): parse in-floor thermostat status messages (msg 17)

### DIFF
--- a/.changeset/in-floor-status-msg-17.md
+++ b/.changeset/in-floor-status-msg-17.md
@@ -1,0 +1,7 @@
+---
+'mysa-js-sdk': patch
+---
+
+Parse the periodic status message (type 17) sent by in-floor heating thermostats (INF-V1-0). These devices publish
+their telemetry as message type 17 rather than type 40, so their updates were silently discarded: floor temperature was
+never reported and power stayed unknown. The heating relay state (`heatStat`) now drives the reported duty cycle.

--- a/packages/mysa-js-sdk/src/api/MysaApiClient.ts
+++ b/packages/mysa-js-sdk/src/api/MysaApiClient.ts
@@ -1286,6 +1286,21 @@ export class MysaApiClient {
             });
             break;
 
+          case OutMessageType.DEVICE_IN_FLOOR_STATUS:
+            // In-floor heating thermostats (INF-V1-0) report their periodic telemetry here rather than as a
+            // DEVICE_V2_STATUS. They drive a plain relay, so heating is expressed as the binary `heatStat` (0 or 1),
+            // which is a valid 0.0-1.0 duty fraction and maps straight onto `dutyCycle`. The body's own `dutyCycle`
+            // field is deliberately ignored: it has been observed pinned to a constant value regardless of the relay.
+            this.emitter.emit('statusChanged', {
+              deviceId: parsedPayload.src.ref,
+              temperature: parsedPayload.body.ambTemp,
+              humidity: parsedPayload.body.hum,
+              setPoint: parsedPayload.body.stpt,
+              dutyCycle: parsedPayload.body.heatStat,
+              floorTemperature: parsedPayload.body.flrSnsrTemp
+            });
+            break;
+
           case OutMessageType.DEVICE_V2_STATUS:
             // In-floor heating thermostats (INF-V1-0) share this message type but report a binary heating-relay state
             // (`heatStat`) instead of a fractional `dtyCycle`, plus a floor-probe temperature. `heatStat` (0 or 1) is a

--- a/packages/mysa-js-sdk/src/types/mqtt/MsgOutPayload.ts
+++ b/packages/mysa-js-sdk/src/types/mqtt/MsgOutPayload.ts
@@ -1,4 +1,5 @@
 import { DeviceAcStatus } from './out/DeviceAcStatus';
+import { DeviceInFloorStatus } from './out/DeviceInFloorStatus';
 import { DeviceStateChange } from './out/DeviceStateChange';
 import { DeviceV2Status } from './out/DeviceV2Status';
 
@@ -8,4 +9,4 @@ import { DeviceV2Status } from './out/DeviceV2Status';
  * This type encompasses payloads where the message type is specified in the `msg` field rather than the `MsgType`
  * field. Includes device status reports and state change notifications.
  */
-export type MsgOutPayload = DeviceAcStatus | DeviceV2Status | DeviceStateChange;
+export type MsgOutPayload = DeviceAcStatus | DeviceInFloorStatus | DeviceV2Status | DeviceStateChange;

--- a/packages/mysa-js-sdk/src/types/mqtt/out/DeviceInFloorStatus.ts
+++ b/packages/mysa-js-sdk/src/types/mqtt/out/DeviceInFloorStatus.ts
@@ -1,0 +1,41 @@
+import { MsgPayload } from '../MsgBasePayload';
+import { OutMessageType } from './OutMessageType';
+
+/**
+ * Interface representing a periodic status report from a Mysa in-floor heating thermostat.
+ *
+ * In-floor units (`INF-V1-0`) publish their telemetry every few seconds as message type 17 rather than the
+ * {@link DeviceV2Status} (type 40) sent by baseboard devices. The body carries the same ambient readings plus the
+ * floor-probe temperature and the binary heating-relay state.
+ */
+export interface DeviceInFloorStatus extends MsgPayload<OutMessageType.DEVICE_IN_FLOOR_STATUS> {
+  /** Source information identifying the device sending the status */
+  src: {
+    /** Reference identifier for the device */
+    ref: string;
+    /** Type identifier for the source device */
+    type: number;
+  };
+  /** Status data payload containing current device measurements and settings */
+  body: {
+    /** Ambient temperature reading from the device sensor (°C) */
+    ambTemp: number;
+    /** Floor-probe temperature reading (°C) */
+    flrSnsrTemp?: number;
+    /** Relative humidity percentage */
+    hum: number;
+    /** Current temperature setpoint (°C) */
+    stpt: number;
+    /** Binary heating-relay state (0 = off, 1 = energized) */
+    heatStat?: number;
+    /**
+     * Reported duty cycle. Observed to stay pinned at a constant value regardless of the relay state on this message
+     * type, so {@link heatStat} is the reliable indicator of whether the device is heating.
+     */
+    dutyCycle?: number;
+    /** Which sensor the thermostat regulates against (3 = floor probe, 5 = ambient air) */
+    trackedSnsr?: number;
+    /** Line voltage (V) */
+    lineVtg?: number;
+  };
+}

--- a/packages/mysa-js-sdk/src/types/mqtt/out/OutMessageType.ts
+++ b/packages/mysa-js-sdk/src/types/mqtt/out/OutMessageType.ts
@@ -25,6 +25,9 @@ export enum OutMessageType {
   // When the message type is reported in the `msg` field of the payload.
   //
 
+  /** Periodic status report from an in-floor heating thermostat (INF-V1-0) */
+  DEVICE_IN_FLOOR_STATUS = 17,
+
   /** Version 2 device status report with enhanced device information */
   DEVICE_V2_STATUS = 40,
 

--- a/packages/mysa-js-sdk/src/types/mqtt/out/index.ts
+++ b/packages/mysa-js-sdk/src/types/mqtt/out/index.ts
@@ -1,4 +1,5 @@
 export * from './DeviceAcStatus';
+export * from './DeviceInFloorStatus';
 export * from './DeviceLog';
 export * from './DevicePostBoot';
 export * from './DeviceSetpointChange';


### PR DESCRIPTION
Fixes #225.

## Problem

`INF-V1-0` in-floor thermostats publish their periodic telemetry as **`msg: 17`**, not `msg: 40`. `_processMqttMessage` only had cases for 30 (AC), 40 (V2/baseboard) and 44 (state-change ack), so these messages were parsed — they still emitted `rawRealtimeMessageReceived` — and then silently dropped. No `statusChanged` ever fired for in-floor devices, so `mysa2mqtt`'s `handleMysaStatusUpdate` (the only place `Current power` and `Floor temperature` are ever set) never ran: power stayed at the literal `None` written at startup, and floor temperature never got a first value. Ambient temperature and humidity kept working because they come from the 60s REST poll.

The `msg: 40` in-floor handling added in #211 was inferred rather than observed; the reporter's captures show this unit only ever sends `msg: 17`.

## Changes

All in `mysa-js-sdk`:

- New `DeviceInFloorStatus` payload type for message 17, added to `OutMessageType` (`DEVICE_IN_FLOOR_STATUS = 17`), the `MsgOutPayload` union, and the barrel export.
- A `DEVICE_IN_FLOOR_STATUS` case in `_processMqttMessage` that emits `statusChanged` with `heatStat → dutyCycle` and `flrSnsrTemp → floorTemperature`.
- Patch changeset.

No change was needed in `mysa2mqtt`: once the event fires, the existing code publishes the floor temperature sensor and derives power from `dutyCycle` × `--heater-watts`.

## Reviewer notes

- **The body's own `dutyCycle` field is deliberately ignored.** The captures in the issue show it pinned at `0.9848` across a relay `1 → 0` transition, while `heatStat` tracks the relay correctly. `heatStat` (0 or 1) is a valid 0.0–1.0 duty fraction, so it maps straight onto `dutyCycle` — same approach as the existing msg 40 path.
- **The in-floor fields on `DeviceV2Status` (msg 40) are left in place.** They're harmless if some firmware does emit both, and removing them would risk a regression that can't be verified without hardware.

## Verification

`npm run style-lint && npm run lint && npm run build && npm run typecheck && npm test` all pass (96 tests).

Replayed the two real `msg: 17` payloads from the issue through the built SDK: both emit `statusChanged` with `floorTemperature: 24.6`, and `dutyCycle` follows `heatStat` (`1`, then `0` after the thermostat was switched off), so power will now alternate between the configured wattage and 0 instead of staying unknown.

Not verifiable here: real `INF-V1-0` hardware. The reporter offered to run further captures and can confirm on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * In-floor heating thermostats now correctly report periodic status updates.
  * Floor temperature, humidity, set point, and heating activity are now reflected accurately.
  * Heating duty cycle now corresponds to the current heating relay state.

* **API Improvements**
  * Added support for in-floor thermostat status messages and their associated status fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->