### PR TITLE
chore(docker): fill in image metadata and add a copyright label

### DIFF
--- a/.changeset/docker-image-metadata.md
+++ b/.changeset/docker-image-metadata.md
@@ -1,0 +1,5 @@
+---
+'mysa2mqtt': patch
+---
+
+Fill in the Docker image metadata Docker Hub shows on the tag's Specifications tab: a full set of OCI labels (title, authors, vendor, url, documentation), a `copyright` label, `NODE_ENV=production`, and the source/revision/created labels and SBOM stamped by the release build.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,29 @@ jobs:
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
+      # Produces the OCI labels a build has to supply because the Dockerfile
+      # cannot know them (version, revision, created), plus the same values as
+      # annotations. `index` is included because the pushed artifact is a
+      # multi-platform index -- annotations on the per-platform manifests alone
+      # are not what registries read.
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+        with:
+          images: bourquep/mysa2mqtt
+          tags: |
+            type=raw,value=${{ needs.release.outputs.mysa2mqtt_version }}
+            type=raw,value=latest
+
       - name: Build and push
         uses: docker/build-push-action@v6
+        env:
+          # Adds org.opencontainers.image.revision/source and, above all,
+          # com.docker.image.source.entrypoint -- the Dockerfile path Docker Hub
+          # uses to link the image back to its source on GitHub.
+          BUILDX_GIT_LABELS: full
         with:
           context: .
           file: ./packages/mysa2mqtt/Dockerfile
@@ -97,9 +118,14 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            bourquep/mysa2mqtt:${{ needs.release.outputs.mysa2mqtt_version }}
-            bourquep/mysa2mqtt:latest
+          # mode=max is already the default for public repositories, but it is
+          # what carries the Dockerfile source and build parameters into the
+          # provenance attestation, so pin it rather than inherit it.
+          provenance: mode=max
+          sbom: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
 
   # Replaces the "released in version x" comments semantic-release used to post.
   # Runs after `docker` so the comment can only claim an image tag that exists.

--- a/packages/mysa2mqtt/Dockerfile
+++ b/packages/mysa2mqtt/Dockerfile
@@ -29,12 +29,26 @@ RUN npm run build
 # Final stage
 FROM node:24-alpine AS final
 
-# Metadata
+# Metadata. The release workflow additionally stamps the labels that only a
+# build knows -- version, revision, created -- via docker/metadata-action, and
+# `com.docker.image.source.entrypoint` via BUILDX_GIT_LABELS. Those override the
+# values below, which are what a plain `docker build` produces.
 LABEL maintainer="Pascal Bourque <pascal@cosmos.moi>"
 LABEL description="Expose Mysa smart thermostats to home automation platforms via MQTT."
+LABEL copyright="Copyright (c) 2025-2026 Pascal Bourque"
+LABEL org.opencontainers.image.title="mysa2mqtt"
 LABEL org.opencontainers.image.source="https://github.com/bourquep/mysa2mqtt"
 LABEL org.opencontainers.image.description="Expose Mysa smart thermostats to home automation platforms via MQTT"
 LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.authors="Pascal Bourque <pascal@cosmos.moi>"
+LABEL org.opencontainers.image.vendor="Pascal Bourque"
+LABEL org.opencontainers.image.url="https://bourquep.github.io/mysa2mqtt/"
+LABEL org.opencontainers.image.documentation="https://bourquep.github.io/mysa2mqtt/"
+# The path Docker Hub and Docker Desktop link "view Dockerfile" to, relative to
+# the repository root.
+LABEL com.docker.image.source.entrypoint="packages/mysa2mqtt/Dockerfile"
+
+ENV NODE_ENV=production
 
 # Install security updates
 RUN apk --no-cache upgrade


### PR DESCRIPTION
## Why

Docker Hub's **Specifications** tab for `bourquep/mysa2mqtt` shows `-` for every field under *Source & Build Information* — Dockerfile link, Git commit, Dockerfile, Build parameters, Entrypoint, CMD, User, Working directory, Environment variables, Ports.

I pulled the published `3.0.2` manifest from the registry before changing anything:

- The amd64 image config **already contains** `User`, `Env`, `Entrypoint` and `WorkingDir` — yet Docker Hub renders them as `-`, while `Labels` (read from the same config) render fine.
- The provenance attestation is **already `mode=max`** — `build-push-action` applies that automatically for public repos — with the base64 Dockerfile, `vcs:revision` and `vcs:source` inside it.
- What was genuinely missing: `org.opencontainers.image.revision` and `com.docker.image.source.entrypoint`. The latter is the label Docker Hub and Docker Desktop use to link an image back to its Dockerfile on GitHub, and it's the most plausible key to the whole panel, which renders as one unit.

## What changed

**`packages/mysa2mqtt/Dockerfile`**

- New `copyright` label matching `LICENSE.txt`. Bare key rather than `org.opencontainers.image.copyright` — that namespace is spec-reserved, and the file already uses bare `maintainer`/`description` keys.
- New OCI `title`, `authors`, `vendor`, `url` and `documentation` labels (the last two point at the docs site from the repo homepage).
- `com.docker.image.source.entrypoint`, so a plain `docker build` also carries the source link.
- `ENV NODE_ENV=production`, which gives *Environment variables* something meaningful beyond the base image's `PATH`/`NODE_VERSION`.

**`.github/workflows/release.yml`**

- `docker/metadata-action@v6` for the `version`/`revision`/`created` labels a Dockerfile cannot know, plus annotations at `manifest,index` level — the pushed artifact is a multi-platform index, and annotations on the per-platform manifests alone are not what registries read. Tags stay pinned to the release version via `type=raw`.
- `BUILDX_GIT_LABELS: full` on the build step, for the git-derived `revision`, `source` and `com.docker.image.source.entrypoint`.
- `provenance: mode=max` pinned explicitly rather than inherited, and `sbom: true` — the image had no SBOM attestation at all.

## Notes for review

- **CMD and Ports stay empty, deliberately.** The CLI takes all its configuration from `M2M_*` env vars and flags with no sensible default arguments, and it opens no listening socket. Filling those in would mean inventing metadata.
- **No guarantee the whole panel populates.** `Entrypoint`/`User`/`Working directory` were already in the image config and still displayed `-`, so part of that display may be gated Docker Hub-side rather than on image content. The source-link labels are the one real gap identifiable from the repo.
- **The changeset is what ships this.** `AGENTS.md` says CI changes need no changeset, but the `docker` job only runs when `mysa2mqtt` is published — without a bump this never reaches Docker Hub. Drop `.changeset/docker-image-metadata.md` if you'd rather it ride along with the next release.

## Verification

Built locally (`docker build -f packages/mysa2mqtt/Dockerfile .`) and inspected the result: all twelve labels land, `Env` includes `NODE_ENV=production`, and the `--help` smoke test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker images now include comprehensive metadata, including title, authors, vendor, source, documentation, copyright, and version details.
  * Release builds now include provenance attestations and software bill of materials (SBOM) information.
  * Docker images run with `NODE_ENV=production` configured by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->