### PR TITLE
fix: honour per-mode fan-speed capabilities (and compare CodeNum numerically)

### DIFF
--- a/.changeset/fan-modes-per-mode.md
+++ b/.changeset/fan-modes-per-mode.md
@@ -1,0 +1,14 @@
+---
+'mysa2mqtt': patch
+---
+
+Stop forwarding fan-mode commands the thermostat's current mode does not support.
+
+Home Assistant's `fan_modes` list is fixed when the entity is discovered, so it has to advertise the union of every
+mode's fan speeds. On a device whose modes differ — an AC-V1-0 offers all four speeds in heat and cool but only `auto`
+in dry — that means the UI can offer a speed the current mode will not accept. Such a command used to be dropped
+silently; worse, the fan speed was validated against the union, so a speed valid in *some* mode was forwarded, and the
+resulting command reapplied the current temperature and mode without changing the fan.
+
+Fan-mode commands are now validated against the current mode's own capabilities and a rejected one is logged with the
+mode and the speeds that mode does support, instead of disappearing.

--- a/.changeset/fan-speeds-per-mode.md
+++ b/.changeset/fan-speeds-per-mode.md
@@ -1,0 +1,24 @@
+---
+'mysa-js-sdk': patch
+---
+
+Send fan-speed commands the device actually accepts in its current mode.
+
+An AC thermostat can accept different fan speeds per mode: an AC-V1-0 driving a mini-split offers auto/low/medium/high
+in heat and cool, but only `auto` in auto and dry, and only low/medium/high in fan-only. The send map was built from the
+device-wide `SupportedCaps.fanSpeeds` alone, so a command was mapped identically in every mode. `setDeviceState` now
+prefers the target mode's own `SupportedCaps.modes[md].fanSpeeds` list, and rejects a speed that mode does not support
+with `UnsupportedFanSpeedError` instead of publishing an `fn` value the unit ignores.
+
+Per-mode lists are mapped by value rather than by position. A mode that omits a speed — fan-only reporting `3, 5, 7`,
+with no `auto` — would otherwise have every speed shifted by one when zipped against the canonical order, so asking for
+`auto` would have set the fan to low. Devices that publish only a device-wide list keep the positional reading, which is
+how that list is defined.
+
+Devices with per-mode lists but no device-wide list previously fell through to the universal legacy mapping. They now
+use their own reported values.
+
+Also fixes the `CodeNum` comparison that selects the canonical `1/2/4/6` fan-speed mapping for AC-V1-X thermostats. The
+REST API reports `CodeNum` as a string (e.g. `"2009"`), so a strict `===` against the numeric literal `1117` never
+matched and those devices silently fell back to the legacy `1/3/5/7` values, which they ignore. The comparison is now
+numeric, and `DeviceBase.CodeNum` is typed `number | string` to match what the API returns.

--- a/packages/mysa-js-sdk/package.json
+++ b/packages/mysa-js-sdk/package.json
@@ -45,6 +45,8 @@
     "example": "tsx --watch ./example/main.ts",
     "example:raw": "MYSA_OUTPUT_RAW_DATA=true tsx --watch ./example/main.ts",
     "lint": "eslint --max-warnings 0 src/**/*.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "build": "tsup",
     "build:docs": "typedoc"

--- a/packages/mysa-js-sdk/src/api/MysaApiClient.ts
+++ b/packages/mysa-js-sdk/src/api/MysaApiClient.ts
@@ -1,4 +1,5 @@
 import { MysaCredentials } from '@/api/MysaCredentials';
+import { buildFanSpeedSendMap, FanSpeedReceiveMap, ModeSendMap } from '@/lib/DeviceCapabilities';
 import { EventEmitter } from '@/lib/EventEmitter';
 import { parseMqttPayload, serializeMqttPayload } from '@/lib/PayloadParser';
 import { isMsgOutPayload, isMsgTypeOutPayload } from '@/lib/PayloadTypeGuards';
@@ -6,7 +7,7 @@ import { ChangeDeviceState } from '@/types/mqtt/in/ChangeDeviceState';
 import { InMessageType } from '@/types/mqtt/in/InMessageType';
 import { StartPublishingDeviceStatus } from '@/types/mqtt/in/StartPublishingDeviceStatus';
 import { OutMessageType } from '@/types/mqtt/out/OutMessageType';
-import { DeviceBase, Devices, DeviceStates, Firmwares, Homes } from '@/types/rest';
+import { Devices, DeviceStates, Firmwares, Homes } from '@/types/rest';
 import { DescribeThingCommand, IoTClient } from '@aws-sdk/client-iot';
 import { fromCognitoIdentityPool } from '@aws-sdk/credential-providers';
 import { AuthenticationDetails, CognitoUser, CognitoUserPool, CognitoUserSession } from 'amazon-cognito-identity-js';
@@ -59,66 +60,6 @@ const MqttResetBaseDelay = dayjs.duration(1, 'second');
 const MqttResetMaxDelay = dayjs.duration(30, 'seconds');
 /** How long a connection must stay interrupt-free before the consecutive-reset counter is cleared. */
 const MqttStabilityWindow = dayjs.duration(60, 'seconds');
-
-/** Canonical fan-speed order, matching the positional layout of a device's `SupportedCaps.fanSpeeds`. */
-const CanonicalFanSpeedOrder: MysaFanSpeedMode[] = ['auto', 'low', 'medium', 'high', 'max'];
-
-/** Universal fan-speed `fn` mapping used when a device does not report its own `SupportedCaps.fanSpeeds`. */
-const LegacyFanSpeedSendMap: Record<MysaFanSpeedMode, number> = { auto: 1, low: 3, medium: 5, high: 7, max: 8 };
-
-/**
- * AC-V1-X (`CodeNum` 1117) canonical fan-speed `fn` mapping. These devices use `1/2/4/6` for auto/low/medium/high but
- * frequently omit an explicit `SupportedCaps.fanSpeeds` list, so the legacy `1/3/5/7` map would send `fn` values they
- * ignore. Used as the no-`fanSpeeds` fallback for CodeNum=1117 devices.
- */
-const CanonicalFanSpeedSendMap: Partial<Record<MysaFanSpeedMode, number>> = { auto: 1, low: 2, medium: 4, high: 6 };
-
-/** `CodeNum` for AC-V1-X thermostats that use the canonical `1/2/4/6` fan-speed `fn` values. */
-const CANONICAL_FAN_SPEED_CODE_NUM = 1117;
-
-/**
- * Receive-side `fn`-to-fan-speed mapping. Includes both the legacy universal values (3/5/7) and the AC-V1-X
- * CodeNum=1117 canonical values (2/4/6); the latter are unused by legacy devices, so there is no conflict.
- */
-const FanSpeedReceiveMap: Record<number, MysaFanSpeedMode> = {
-  1: 'auto',
-  2: 'low', // CodeNum=1117 canonical low
-  3: 'low', // legacy
-  4: 'medium', // CodeNum=1117 canonical medium
-  5: 'medium', // legacy
-  6: 'high', // CodeNum=1117 canonical high
-  7: 'high', // legacy
-  8: 'max'
-};
-
-/**
- * Builds the send-side fan-speed `fn` mapping for a device.
- *
- * When the device reports `SupportedCaps.fanSpeeds`, its values are zipped positionally with
- * {@link CanonicalFanSpeedOrder} (e.g. `[1, 2, 4, 6]` → `{ auto: 1, low: 2, medium: 4, high: 6 }`). Otherwise, a
- * CodeNum=1117 (AC-V1-X) device uses the {@link CanonicalFanSpeedSendMap} (it uses canonical `fn` values even without
- * enumerating them), and any other device uses the {@link LegacyFanSpeedSendMap}, preserving backward compatibility.
- *
- * @param device - The device to build the mapping for.
- * @returns A partial map from fan-speed mode to the device-specific `fn` value.
- */
-function buildFanSpeedSendMap(device: DeviceBase): Partial<Record<MysaFanSpeedMode, number>> {
-  const fanSpeeds = device.SupportedCaps?.fanSpeeds;
-  if (!fanSpeeds || fanSpeeds.length === 0) {
-    // CodeNum=1117 (AC-V1-X) devices use canonical fn values (1/2/4/6) but frequently omit an explicit
-    // SupportedCaps.fanSpeeds list. The legacy map (1/3/5/7) would send fn values these devices ignore, so
-    // fall back to the canonical map for them; all other no-fanSpeeds devices keep the legacy universal map.
-    return device.CodeNum === CANONICAL_FAN_SPEED_CODE_NUM ? CanonicalFanSpeedSendMap : LegacyFanSpeedSendMap;
-  }
-
-  const map: Partial<Record<MysaFanSpeedMode, number>> = {};
-  CanonicalFanSpeedOrder.forEach((name, index) => {
-    if (index < fanSpeeds.length) {
-      map[name] = fanSpeeds[index];
-    }
-  });
-  return map;
-}
 
 /**
  * Main client for interacting with the Mysa API and real-time device communication.
@@ -509,11 +450,11 @@ export class MysaApiClient {
     const now = dayjs();
 
     this._logger.debug(`Sending request to set device state for '${deviceId}'...`);
-    const modeMap = { off: 1, auto: 2, heat: 3, cool: 4, fan_only: 5, dry: 6 };
-    const fanSpeedMap = buildFanSpeedSendMap(device);
+    const fanSpeedMap = buildFanSpeedSendMap(device, mode);
 
     // Reject an unsupported fan speed (e.g. 'max' on a device whose SupportedCaps.fanSpeeds only covers auto/low/
-    // medium/high) rather than silently publishing fn: undefined, which the caller would perceive as a no-op.
+    // medium/high, or any speed but 'auto' on an AC-V1-0 in dry mode) rather than silently publishing fn: undefined,
+    // which the caller would perceive as a no-op.
     if (fanSpeed !== undefined && fanSpeedMap[fanSpeed] === undefined) {
       throw new UnsupportedFanSpeedError(deviceId, fanSpeed, Object.keys(fanSpeedMap));
     }
@@ -550,7 +491,7 @@ export class MysaApiClient {
           {
             tm: -1,
             sp: setPoint,
-            md: mode ? modeMap[mode] : undefined,
+            md: mode ? ModeSendMap[mode] : undefined,
             fn: fanSpeed ? fanSpeedMap[fanSpeed] : undefined
           }
         ]

--- a/packages/mysa-js-sdk/src/lib/DeviceCapabilities.ts
+++ b/packages/mysa-js-sdk/src/lib/DeviceCapabilities.ts
@@ -1,0 +1,180 @@
+/*
+mysa-js-sdk
+Copyright (C) 2025-2026 Pascal Bourque
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import { MysaDeviceMode, MysaFanSpeedMode } from '@/api/MysaDeviceMode';
+import { DeviceBase, SupportedCaps } from '@/types/rest';
+
+/**
+ * Interpretation of a device's reported `SupportedCaps`.
+ *
+ * Internal to the SDK: these helpers are not re-exported from the package barrel.
+ */
+
+/** Canonical fan-speed order, matching the positional layout of a device's `SupportedCaps.fanSpeeds`. */
+export const CanonicalFanSpeedOrder: MysaFanSpeedMode[] = ['auto', 'low', 'medium', 'high', 'max'];
+
+/** Universal fan-speed `fn` mapping used when a device does not report its own `SupportedCaps.fanSpeeds`. */
+export const LegacyFanSpeedSendMap: Record<MysaFanSpeedMode, number> = {
+  auto: 1,
+  low: 3,
+  medium: 5,
+  high: 7,
+  max: 8
+};
+
+/**
+ * AC-V1-X (`CodeNum` 1117) canonical fan-speed `fn` mapping. These devices use `1/2/4/6` for auto/low/medium/high but
+ * frequently omit an explicit `SupportedCaps.fanSpeeds` list, so the legacy `1/3/5/7` map would send `fn` values they
+ * ignore. Used as the no-`fanSpeeds` fallback for CodeNum=1117 devices.
+ */
+export const CanonicalFanSpeedSendMap: Partial<Record<MysaFanSpeedMode, number>> = {
+  auto: 1,
+  low: 2,
+  medium: 4,
+  high: 6
+};
+
+/** `CodeNum` for AC-V1-X thermostats that use the canonical `1/2/4/6` fan-speed `fn` values. */
+export const CANONICAL_FAN_SPEED_CODE_NUM = 1117;
+
+/**
+ * Receive-side `fn`-to-fan-speed mapping. Includes both the legacy universal values (3/5/7) and the AC-V1-X
+ * CodeNum=1117 canonical values (2/4/6); the latter are unused by legacy devices, so there is no conflict.
+ */
+export const FanSpeedReceiveMap: Record<number, MysaFanSpeedMode> = {
+  1: 'auto',
+  2: 'low', // CodeNum=1117 canonical low
+  3: 'low', // legacy
+  4: 'medium', // CodeNum=1117 canonical medium
+  5: 'medium', // legacy
+  6: 'high', // CodeNum=1117 canonical high
+  7: 'high', // legacy
+  8: 'max'
+};
+
+/** Raw `md` values for each mode. Doubles as the key into `SupportedCaps.modes`, which is indexed by the same value. */
+export const ModeSendMap: Record<MysaDeviceMode, number> = { off: 1, auto: 2, heat: 3, cool: 4, fan_only: 5, dry: 6 };
+
+/**
+ * Maps a set of raw `fn` values onto fan speeds by value, via {@link FanSpeedReceiveMap}.
+ *
+ * Unlike the positional reading of a top-level `SupportedCaps.fanSpeeds` list, this is order-independent, which is what
+ * a per-mode list requires: a mode that omits a speed (e.g. fan-only offering `[3, 5, 7]` — low/medium/high, with no
+ * `auto`) would have every speed shifted by one if it were zipped against {@link CanonicalFanSpeedOrder}.
+ *
+ * @param rawSpeeds - The raw `fn` values the device accepts.
+ * @returns A partial map from fan speed to `fn` value, empty when no value is recognized.
+ */
+export function mapFanSpeedsByValue(rawSpeeds: number[]): Partial<Record<MysaFanSpeedMode, number>> {
+  const map: Partial<Record<MysaFanSpeedMode, number>> = {};
+
+  for (const rawSpeed of rawSpeeds) {
+    const fanSpeed = FanSpeedReceiveMap[rawSpeed];
+    // First value wins, so a list carrying both the legacy and the canonical encoding of one speed is deterministic.
+    if (fanSpeed !== undefined && map[fanSpeed] === undefined) {
+      map[fanSpeed] = rawSpeed;
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Collects the union of every mode's `fanSpeeds` list.
+ *
+ * @param supportedCaps - The device's supported capabilities, if reported.
+ * @returns The raw `fn` values accepted by at least one mode.
+ */
+export function collectModeFanSpeeds(supportedCaps: SupportedCaps | undefined): number[] {
+  const rawSpeeds = new Set<number>();
+
+  for (const modeCaps of Object.values(supportedCaps?.modes ?? {})) {
+    for (const rawSpeed of modeCaps.fanSpeeds ?? []) {
+      rawSpeeds.add(rawSpeed);
+    }
+  }
+
+  return [...rawSpeeds];
+}
+
+/**
+ * Builds the send-side fan-speed `fn` mapping for a device, for the mode the command will leave it in.
+ *
+ * Sources are consulted from most to least specific:
+ *
+ * 1. The target mode's own `SupportedCaps.modes[md].fanSpeeds`, mapped by value. A device can accept different speeds per
+ *    mode — an AC-V1-0 offers all four in heat and cool, but only `auto` in dry — and only this list reflects that.
+ * 2. The device-wide `SupportedCaps.fanSpeeds`, zipped positionally with {@link CanonicalFanSpeedOrder}, so that a list of
+ *    `1, 2, 4, 6` reads as auto, low, medium and high respectively.
+ * 3. The union of every mode's list, mapped by value — for devices that enumerate speeds per mode but publish no
+ *    device-wide list, and for callers that did not name a mode.
+ * 4. Failing all of those, CodeNum=1117 (AC-V1-X) devices use the {@link CanonicalFanSpeedSendMap} (they use canonical `fn`
+ *    values even without enumerating them) and every other device the {@link LegacyFanSpeedSendMap}, preserving backward
+ *    compatibility.
+ *
+ * @param device - The device to build the mapping for.
+ * @param mode - The mode the device will be in, when known. Without it the mapping cannot be mode-specific and falls
+ *   through to the device-wide sources.
+ * @returns A partial map from fan speed to the device-specific `fn` value.
+ */
+export function buildFanSpeedSendMap(
+  device: DeviceBase,
+  mode?: MysaDeviceMode
+): Partial<Record<MysaFanSpeedMode, number>> {
+  const supportedCaps = device.SupportedCaps;
+
+  const modeFanSpeeds = mode !== undefined ? supportedCaps?.modes?.[ModeSendMap[mode]]?.fanSpeeds : undefined;
+  if (modeFanSpeeds && modeFanSpeeds.length > 0) {
+    const map = mapFanSpeedsByValue(modeFanSpeeds);
+    // An empty map means the device enumerated `fn` values this SDK does not know. Fall through rather than reject
+    // every fan command for it.
+    if (Object.keys(map).length > 0) {
+      return map;
+    }
+  }
+
+  const fanSpeeds = supportedCaps?.fanSpeeds;
+  if (fanSpeeds && fanSpeeds.length > 0) {
+    const map: Partial<Record<MysaFanSpeedMode, number>> = {};
+    CanonicalFanSpeedOrder.forEach((name, index) => {
+      if (index < fanSpeeds.length) {
+        map[name] = fanSpeeds[index];
+      }
+    });
+    return map;
+  }
+
+  const unionFanSpeeds = collectModeFanSpeeds(supportedCaps);
+  if (unionFanSpeeds.length > 0) {
+    const map = mapFanSpeedsByValue(unionFanSpeeds);
+    if (Object.keys(map).length > 0) {
+      return map;
+    }
+  }
+
+  // CodeNum=1117 (AC-V1-X) devices use canonical fn values (1/2/4/6) but frequently omit an explicit
+  // SupportedCaps.fanSpeeds list. The legacy map (1/3/5/7) would send fn values these devices ignore, so
+  // fall back to the canonical map for them; all other no-fanSpeeds devices keep the legacy universal map.
+  // CodeNum is compared numerically because the REST API reports it as a string.
+  return Number(device.CodeNum) === CANONICAL_FAN_SPEED_CODE_NUM ? CanonicalFanSpeedSendMap : LegacyFanSpeedSendMap;
+}

--- a/packages/mysa-js-sdk/src/types/rest/Devices.ts
+++ b/packages/mysa-js-sdk/src/types/rest/Devices.ts
@@ -131,8 +131,14 @@ export interface DeviceBase {
   Brand?: BrandInfo;
   /** Optional supported capabilities for AC devices */
   SupportedCaps?: SupportedCaps;
-  /** Optional device code number */
-  CodeNum?: number;
+  /**
+   * Optional device code number, identifying the IR code set an AC controller drives its unit with.
+   *
+   * The REST API reports this as a string (e.g. `"2009"`) even though the value is numeric, and has been observed to do
+   * so for every device. Coerce with `Number()` before comparing — a strict `===` against a numeric literal silently
+   * never matches.
+   */
+  CodeNum?: number | string;
 }
 
 /**

--- a/packages/mysa-js-sdk/test/DeviceCapabilities.test.ts
+++ b/packages/mysa-js-sdk/test/DeviceCapabilities.test.ts
@@ -1,0 +1,127 @@
+import { buildFanSpeedSendMap } from '@/lib/DeviceCapabilities';
+import { DeviceBase, SupportedCaps } from '@/types/rest';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `SupportedCaps` as actually reported by an AC-V1-0 driving a DAIKIN mini-split (caps version 1.2, `CodeNum` "2009").
+ *
+ * The shape that matters: no device-wide `fanSpeeds` list, and a per-mode list that differs by mode — all four speeds
+ * in heat and cool, `auto` only in auto and dry, and everything _but_ `auto` in fan-only.
+ */
+const AC_V1_0_CAPS: SupportedCaps = {
+  tempRange: [16, 30],
+  version: '1.2',
+  keys: [3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 21, 39, 40],
+  modes: {
+    2: { temperatures: [16, 30], fanSpeeds: [1] }, // auto
+    3: { temperatures: [16, 30], fanSpeeds: [1, 3, 5, 7] }, // heat
+    4: { temperatures: [16, 30], fanSpeeds: [1, 3, 5, 7] }, // cool
+    5: { temperatures: [25], fanSpeeds: [3, 5, 7] }, // fan_only
+    6: { temperatures: [16, 30], fanSpeeds: [1] } // dry
+  }
+};
+
+function device(overrides: Partial<DeviceBase> = {}): DeviceBase {
+  return { Id: '5443b2005580', Model: 'AC-V1-0', ...overrides };
+}
+
+describe('buildFanSpeedSendMap', () => {
+  describe('per-mode fan speeds', () => {
+    it('uses the requested mode’s own list', () => {
+      const map = buildFanSpeedSendMap(device({ SupportedCaps: AC_V1_0_CAPS }), 'cool');
+
+      expect(map).toEqual({ auto: 1, low: 3, medium: 5, high: 7 });
+    });
+
+    it('offers only auto in a mode that supports nothing else', () => {
+      const map = buildFanSpeedSendMap(device({ SupportedCaps: AC_V1_0_CAPS }), 'dry');
+
+      expect(map).toEqual({ auto: 1 });
+    });
+
+    it('does not shift speeds in a mode whose list omits auto', () => {
+      const map = buildFanSpeedSendMap(device({ SupportedCaps: AC_V1_0_CAPS }), 'fan_only');
+
+      // Zipping [3, 5, 7] positionally against [auto, low, medium, high] would read 3 as `auto`, sending the fan to
+      // low whenever auto was asked for. Mapping by value keeps 3 as `low` and leaves `auto` unsupported.
+      expect(map).toEqual({ low: 3, medium: 5, high: 7 });
+      expect(map.auto).toBeUndefined();
+    });
+
+    it('falls back to the union across modes when no mode is given', () => {
+      const map = buildFanSpeedSendMap(device({ SupportedCaps: AC_V1_0_CAPS }));
+
+      expect(map).toEqual({ auto: 1, low: 3, medium: 5, high: 7 });
+    });
+
+    it('falls back to the device-wide list for a mode that enumerates no speeds', () => {
+      const caps: SupportedCaps = { ...AC_V1_0_CAPS, fanSpeeds: [1, 2, 4, 6], modes: { 4: { temperatures: [20] } } };
+
+      expect(buildFanSpeedSendMap(device({ SupportedCaps: caps }), 'cool')).toEqual({
+        auto: 1,
+        low: 2,
+        medium: 4,
+        high: 6
+      });
+    });
+
+    it('prefers the per-mode list over the device-wide one', () => {
+      const caps: SupportedCaps = {
+        ...AC_V1_0_CAPS,
+        fanSpeeds: [1, 2, 4, 6],
+        modes: { 6: { temperatures: [20], fanSpeeds: [1] } }
+      };
+
+      expect(buildFanSpeedSendMap(device({ SupportedCaps: caps }), 'dry')).toEqual({ auto: 1 });
+    });
+
+    it('ignores a per-mode list of unrecognized values rather than rejecting every speed', () => {
+      const caps: SupportedCaps = { ...AC_V1_0_CAPS, modes: { 4: { temperatures: [20], fanSpeeds: [91, 92] } } };
+
+      // Nothing in the list maps to a known speed, so the device-wide fallbacks still apply.
+      expect(buildFanSpeedSendMap(device({ SupportedCaps: caps }), 'cool')).toEqual({
+        auto: 1,
+        low: 3,
+        medium: 5,
+        high: 7,
+        max: 8
+      });
+    });
+  });
+
+  describe('device-wide fan speeds', () => {
+    it('zips a device-wide list positionally', () => {
+      const caps: SupportedCaps = { ...AC_V1_0_CAPS, fanSpeeds: [1, 2, 4, 6], modes: {} };
+
+      expect(buildFanSpeedSendMap(device({ SupportedCaps: caps }))).toEqual({ auto: 1, low: 2, medium: 4, high: 6 });
+    });
+  });
+
+  describe('CodeNum fallback', () => {
+    it('uses the canonical map when CodeNum is the string the REST API actually returns', () => {
+      // The REST API reports CodeNum as a string; a strict === against 1117 never matched, so these devices silently
+      // fell back to the legacy map and every non-auto fan command was ignored by the unit.
+      const map = buildFanSpeedSendMap(device({ CodeNum: '1117' }));
+
+      expect(map).toEqual({ auto: 1, low: 2, medium: 4, high: 6 });
+    });
+
+    it('uses the canonical map when CodeNum is numeric', () => {
+      expect(buildFanSpeedSendMap(device({ CodeNum: 1117 }))).toEqual({ auto: 1, low: 2, medium: 4, high: 6 });
+    });
+
+    it('uses the legacy map for any other device', () => {
+      expect(buildFanSpeedSendMap(device({ CodeNum: '2009' }))).toEqual({
+        auto: 1,
+        low: 3,
+        medium: 5,
+        high: 7,
+        max: 8
+      });
+    });
+
+    it('uses the legacy map when no CodeNum is reported', () => {
+      expect(buildFanSpeedSendMap(device())).toEqual({ auto: 1, low: 3, medium: 5, high: 7, max: 8 });
+    });
+  });
+});

--- a/packages/mysa-js-sdk/vitest.config.ts
+++ b/packages/mysa-js-sdk/vitest.config.ts
@@ -1,0 +1,14 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src')
+    }
+  },
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts']
+  }
+});

--- a/packages/mysa2mqtt/package.json
+++ b/packages/mysa2mqtt/package.json
@@ -48,7 +48,9 @@
     "capture": "tsx src/capture.ts",
     "lint": "eslint --max-warnings 0 src/**/*.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "build": "tsup"
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "commander": "15.0.0",

--- a/packages/mysa2mqtt/src/thermostat.ts
+++ b/packages/mysa2mqtt/src/thermostat.ts
@@ -102,6 +102,8 @@ const REALTIME_RETRY_MAX_EXPONENT = Math.ceil(Math.log2(REALTIME_RETRY_MAX_DELAY
  *
  *   - No SupportedCaps at all → expose all modes (we have no data, so be permissive)
  *   - A `mode` was given and that mode enumerates fanSpeeds → expose exactly those speeds
+ *   - A `mode` was given but enumerates none → expose the device-wide fanSpeeds, matching what the SDK will send for that
+ *       mode; a wider union would accept speeds the SDK then rejects
  *   - SupportedCaps present with fanSpeeds → expose exactly those speeds
  *   - SupportedCaps present, no fanSpeeds, but the FanSpeed key IS in `keys` → the device supports multi-speed control but
  *       doesn't enumerate its speeds (e.g. AC-V1-0 with a configured brand whose generic IR code set omits
@@ -117,14 +119,25 @@ export function buildFanModes(supportedCaps: SupportedCaps | undefined, mode?: M
 
   const rawMode = mode !== undefined ? DEVICE_MODE_TO_MYSA_RAW_MODE[mode] : undefined;
   const modeSpeeds = rawMode !== undefined ? supportedCaps.modes[rawMode]?.fanSpeeds : undefined;
+  // Raw values this bridge cannot name are dropped by the filter at the end of this function. Were they left in
+  // here, a mode enumerating nothing else would produce an empty list and reject every fan-speed command for
+  // that mode; ignore them and fall back instead, the way the SDK's send map does.
+  const namedModeSpeeds = modeSpeeds?.filter((speed) => MYSA_RAW_FAN_SPEED_TO_FAN_SPEED_MODE[speed] !== undefined);
 
-  if (modeSpeeds && modeSpeeds.length > 0) {
+  if (namedModeSpeeds && namedModeSpeeds.length > 0) {
     // The requested mode states its own speeds — the most specific answer available.
-    for (const speed of modeSpeeds) {
+    for (const speed of namedModeSpeeds) {
+      allSpeeds.add(speed);
+    }
+  } else if (mode !== undefined && supportedCaps.fanSpeeds && supportedCaps.fanSpeeds.length > 0) {
+    // A mode was named, but says nothing usable about its own speeds. The SDK builds this device's send map from
+    // the device-wide list alone, so validating against a wider union would accept speeds it then rejects.
+    for (const speed of supportedCaps.fanSpeeds) {
       allSpeeds.add(speed);
     }
   } else {
-    // No mode was named, or the named one does not enumerate its speeds: fall back to what the device says overall.
+    // Discovery, where no mode is named and Home Assistant's fixed fan_modes list has to cover every mode; or a
+    // device with no device-wide list to fall back on. Take everything the device reports.
 
     // Check top-level fanSpeeds first (API returns this for CodeNum=1117 devices)
     if (supportedCaps.fanSpeeds) {

--- a/packages/mysa2mqtt/src/thermostat.ts
+++ b/packages/mysa2mqtt/src/thermostat.ts
@@ -56,6 +56,11 @@ const MYSA_RAW_MODE_TO_DEVICE_MODE: Partial<Record<number, MysaDeviceMode>> = {
   6: 'dry'
 };
 
+/** Inverse of {@link MYSA_RAW_MODE_TO_DEVICE_MODE}, for indexing into `SupportedCaps.modes`. */
+const DEVICE_MODE_TO_MYSA_RAW_MODE = Object.fromEntries(
+  Object.entries(MYSA_RAW_MODE_TO_DEVICE_MODE).map(([rawMode, mode]) => [mode, Number(rawMode)])
+) as Partial<Record<MysaDeviceMode, number>>;
+
 const FAN_SPEED_MODES: Partial<MysaFanSpeedMode>[] = ['auto', 'low', 'medium', 'high', 'max'];
 const MYSA_RAW_FAN_SPEED_TO_FAN_SPEED_MODE: Partial<Record<number, MysaFanSpeedMode>> = {
   1: 'auto',
@@ -87,37 +92,52 @@ const REALTIME_RETRY_MAX_DELAY_MS = 300_000;
 const REALTIME_RETRY_MAX_EXPONENT = Math.ceil(Math.log2(REALTIME_RETRY_MAX_DELAY_MS / REALTIME_RETRY_INITIAL_DELAY_MS));
 
 /**
- * Build the fan_modes list from the device's SupportedCaps. Takes the union of fanSpeeds across all modes, preserving
- * canonical order.
+ * Build the fan_modes list from the device's SupportedCaps, for one mode or for the device as a whole.
  *
  * @param supportedCaps - The device's supported capabilities, if reported.
+ * @param mode - When given, report only the speeds this mode accepts. A device can accept different speeds per mode —
+ *   an AC-V1-0 offers all four in heat and cool but only `auto` in dry — so this is what a command must be validated
+ *   against. Omit it for the device-wide union that discovery advertises.
  * @returns The supported fan speed modes, falling back to {@link FAN_SPEED_MODES} when none are reported.
  *
  *   - No SupportedCaps at all → expose all modes (we have no data, so be permissive)
+ *   - A `mode` was given and that mode enumerates fanSpeeds → expose exactly those speeds
  *   - SupportedCaps present with fanSpeeds → expose exactly those speeds
  *   - SupportedCaps present, no fanSpeeds, but the FanSpeed key IS in `keys` → the device supports multi-speed control but
  *       doesn't enumerate its speeds (e.g. AC-V1-0 with a configured brand whose generic IR code set omits
  *       `fanSpeeds`). Advertise the canonical AC speeds — the SDK send path drives them via `LegacyFanSpeedSendMap`.
  *   - SupportedCaps present, no fanSpeeds, and no FanSpeed key → genuinely single-speed / Brand=None → expose only 'auto'
  */
-function buildFanModes(supportedCaps: SupportedCaps | undefined): MysaFanSpeedMode[] {
+export function buildFanModes(supportedCaps: SupportedCaps | undefined, mode?: MysaDeviceMode): MysaFanSpeedMode[] {
   if (!supportedCaps?.modes) {
     return [...FAN_SPEED_MODES] as MysaFanSpeedMode[];
   }
 
   const allSpeeds = new Set<number>();
 
-  // Check top-level fanSpeeds first (API returns this for CodeNum=1117 devices)
-  if (supportedCaps.fanSpeeds) {
-    for (const speed of supportedCaps.fanSpeeds) {
+  const rawMode = mode !== undefined ? DEVICE_MODE_TO_MYSA_RAW_MODE[mode] : undefined;
+  const modeSpeeds = rawMode !== undefined ? supportedCaps.modes[rawMode]?.fanSpeeds : undefined;
+
+  if (modeSpeeds && modeSpeeds.length > 0) {
+    // The requested mode states its own speeds — the most specific answer available.
+    for (const speed of modeSpeeds) {
       allSpeeds.add(speed);
     }
-  }
+  } else {
+    // No mode was named, or the named one does not enumerate its speeds: fall back to what the device says overall.
 
-  // Also check per-mode fanSpeeds (future-proofing)
-  for (const modeCaps of Object.values(supportedCaps.modes)) {
-    for (const speed of modeCaps.fanSpeeds ?? []) {
-      allSpeeds.add(speed);
+    // Check top-level fanSpeeds first (API returns this for CodeNum=1117 devices)
+    if (supportedCaps.fanSpeeds) {
+      for (const speed of supportedCaps.fanSpeeds) {
+        allSpeeds.add(speed);
+      }
+    }
+
+    // Also check per-mode fanSpeeds (future-proofing)
+    for (const modeCaps of Object.values(supportedCaps.modes)) {
+      for (const speed of modeCaps.fanSpeeds ?? []) {
+        allSpeeds.add(speed);
+      }
     }
   }
 
@@ -227,6 +247,8 @@ export class Thermostat {
           min_temp: mysaDevice.MinSetpoint,
           max_temp: mysaDevice.MaxSetpoint,
           modes: isAC ? HA_AC_MODES : HA_HEAT_ONLY_MODES,
+          // Home Assistant's fan_modes list is fixed at discovery time, so it has to be the union across every mode.
+          // Where a mode accepts fewer speeds, the command handler below rejects the difference.
           fan_modes: isAC ? buildFanModes(mysaDevice.SupportedCaps) : undefined,
           precision: is_celsius ? 0.1 : 1.0,
           temp_step: is_celsius ? 0.5 : 1.0,
@@ -296,17 +318,21 @@ export class Thermostat {
 
           case 'fan_mode_command_topic': {
             const messageAsMode = message as MysaFanSpeedMode;
-            const supportedModes = buildFanModes(this.mysaDevice.SupportedCaps);
+            const currentMode = this.mqttClimate.currentMode as MysaDeviceMode | undefined;
+            const supportedModes = buildFanModes(this.mysaDevice.SupportedCaps, currentMode);
             if (!supportedModes.includes(messageAsMode)) {
-              // Ignore unsupported fan modes entirely; forwarding them would omit fanSpeed but
+              // Discovery advertises the union of every mode's speeds, so Home Assistant can offer one the
+              // *current* mode does not accept. Ignore it entirely; forwarding it would omit fanSpeed but
               // still reapply the current temperature/mode, which is not a no-op.
+              this.logger.warn('Ignoring a fan mode the current device mode does not support', {
+                deviceId: this.mysaDevice.Id,
+                fanMode: messageAsMode,
+                mode: currentMode,
+                supportedFanModes: supportedModes
+              });
               break;
             }
-            await this.setDeviceState(
-              this.mqttClimate.targetTemperature,
-              this.mqttClimate.currentMode as MysaDeviceMode,
-              messageAsMode
-            );
+            await this.setDeviceState(this.mqttClimate.targetTemperature, currentMode, messageAsMode);
             break;
           }
         }

--- a/packages/mysa2mqtt/test/thermostat.test.ts
+++ b/packages/mysa2mqtt/test/thermostat.test.ts
@@ -1,0 +1,71 @@
+import { SupportedCaps } from 'mysa-js-sdk';
+import { describe, expect, it, vi } from 'vitest';
+
+// thermostat.ts pulls `version` from options.ts, whose module body parses process.argv and exits when the mandatory
+// credential options are absent — which they are under vitest.
+vi.mock('@/options', () => ({ version: '0.0.0-test' }));
+
+const { buildFanModes } = await import('@/thermostat');
+
+/**
+ * `SupportedCaps` as actually reported by an AC-V1-0 driving a DAIKIN mini-split (caps version 1.2). No device-wide
+ * `fanSpeeds` list, and a per-mode list that differs by mode.
+ */
+const AC_V1_0_CAPS: SupportedCaps = {
+  tempRange: [16, 30],
+  version: '1.2',
+  keys: [3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 21, 39, 40],
+  modes: {
+    2: { temperatures: [16, 30], fanSpeeds: [1] }, // auto
+    3: { temperatures: [16, 30], fanSpeeds: [1, 3, 5, 7] }, // heat
+    4: { temperatures: [16, 30], fanSpeeds: [1, 3, 5, 7] }, // cool
+    5: { temperatures: [25], fanSpeeds: [3, 5, 7] }, // fan_only
+    6: { temperatures: [16, 30], fanSpeeds: [1] } // dry
+  }
+};
+
+describe('buildFanModes', () => {
+  it('advertises the union across modes when no mode is given', () => {
+    // This is what discovery publishes: Home Assistant's fan_modes list is fixed, so it has to cover every mode.
+    expect(buildFanModes(AC_V1_0_CAPS)).toEqual(['auto', 'low', 'medium', 'high']);
+  });
+
+  it('reports every speed for a mode that supports them all', () => {
+    expect(buildFanModes(AC_V1_0_CAPS, 'cool')).toEqual(['auto', 'low', 'medium', 'high']);
+  });
+
+  it('reports only auto for a mode that runs the fan at a fixed speed', () => {
+    expect(buildFanModes(AC_V1_0_CAPS, 'dry')).toEqual(['auto']);
+    expect(buildFanModes(AC_V1_0_CAPS, 'auto')).toEqual(['auto']);
+  });
+
+  it('omits auto for a mode that does not offer it', () => {
+    expect(buildFanModes(AC_V1_0_CAPS, 'fan_only')).toEqual(['low', 'medium', 'high']);
+  });
+
+  it('falls back to the device-wide union for a mode that enumerates no speeds', () => {
+    const caps: SupportedCaps = { ...AC_V1_0_CAPS, modes: { ...AC_V1_0_CAPS.modes, 6: { temperatures: [20] } } };
+
+    expect(buildFanModes(caps, 'dry')).toEqual(['auto', 'low', 'medium', 'high']);
+  });
+
+  it('falls back to the device-wide union for a mode the device does not report at all', () => {
+    expect(buildFanModes(AC_V1_0_CAPS, 'off')).toEqual(['auto', 'low', 'medium', 'high']);
+  });
+
+  it('is permissive when the device reports no capabilities', () => {
+    expect(buildFanModes(undefined)).toEqual(['auto', 'low', 'medium', 'high', 'max']);
+  });
+
+  it('advertises the canonical speeds when fan support is declared only through keys', () => {
+    const caps: SupportedCaps = { tempRange: [16, 30], version: '1.2', keys: [3, 4], modes: {} };
+
+    expect(buildFanModes(caps)).toEqual(['auto', 'low', 'medium', 'high']);
+  });
+
+  it('advertises auto only when the device declares no fan support', () => {
+    const caps: SupportedCaps = { tempRange: [16, 30], version: '1.2', keys: [3], modes: {} };
+
+    expect(buildFanModes(caps)).toEqual(['auto']);
+  });
+});

--- a/packages/mysa2mqtt/test/thermostat.test.ts
+++ b/packages/mysa2mqtt/test/thermostat.test.ts
@@ -49,6 +49,31 @@ describe('buildFanModes', () => {
     expect(buildFanModes(caps, 'dry')).toEqual(['auto', 'low', 'medium', 'high']);
   });
 
+  it('ignores a per-mode list of unrecognized values rather than rejecting every speed', () => {
+    const caps: SupportedCaps = {
+      ...AC_V1_0_CAPS,
+      modes: { ...AC_V1_0_CAPS.modes, 4: { temperatures: [20], fanSpeeds: [91, 92] } }
+    };
+
+    // Carrying 91/92 through would leave nothing after the raw-value filter, and an empty list rejects every
+    // fan-speed command for the mode. The SDK's send map falls through in the same situation.
+    expect(buildFanModes(caps, 'cool')).toEqual(['auto', 'low', 'medium', 'high']);
+  });
+
+  it('prefers the device-wide list alone for a mode that enumerates none, matching the SDK send map', () => {
+    const caps: SupportedCaps = {
+      tempRange: [16, 30],
+      version: '1.2',
+      keys: [3, 4],
+      fanSpeeds: [1, 2, 4],
+      modes: { 4: { temperatures: [20] }, 5: { temperatures: [25], fanSpeeds: [7] } }
+    };
+
+    // `high` comes only from fan-only. Advertising it for cool would pass validation here and then fail in the
+    // SDK, which builds cool's send map from the device-wide list alone.
+    expect(buildFanModes(caps, 'cool')).toEqual(['auto', 'low', 'medium']);
+  });
+
   it('falls back to the device-wide union for a mode the device does not report at all', () => {
     expect(buildFanModes(AC_V1_0_CAPS, 'off')).toEqual(['auto', 'low', 'medium', 'high']);
   });

--- a/packages/mysa2mqtt/vitest.config.ts
+++ b/packages/mysa2mqtt/vitest.config.ts
@@ -1,0 +1,14 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src')
+    }
+  },
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts']
+  }
+});


### PR DESCRIPTION
An AC thermostat can accept different fan speeds in different modes, and nothing on either the send path or the validation path read `SupportedCaps` that way. Three defects fall out of that, all reproduced against an AC-V1-0 driving a DAIKIN mini-split (caps version 1.2, `CodeNum` `"2009"`, firmware 3.17.5.9), which reports:

| mode | `fanSpeeds` |
| --- | --- |
| auto (2) | `[1]` |
| heat (3) | `[1, 3, 5, 7]` |
| cool (4) | `[1, 3, 5, 7]` |
| fan_only (5) | `[3, 5, 7]` |
| dry (6) | `[1]` |

No device-wide `SupportedCaps.fanSpeeds` at all.

### 1. The send map ignored per-mode lists — `mysa-js-sdk`

`buildFanSpeedSendMap` read only the device-wide `SupportedCaps.fanSpeeds`, so every mode got the same mapping. Asking for `high` while the unit is in dry mode published an `fn` the device ignores. It now prefers the target mode's own list, which lets the existing `UnsupportedFanSpeedError` reject the speed instead of silently doing nothing.

### 2. Per-mode lists cannot be read positionally — `mysa-js-sdk`

A device-wide `fanSpeeds` list is defined positionally (`[1, 2, 4, 6]` → auto/low/medium/high), but a per-mode list is just the set of values that mode accepts. Fan-only above reports `[3, 5, 7]` — no `auto` — so zipping it against the canonical order reads `3` as `auto`, and asking for auto would set the fan to low. Per-mode lists are therefore mapped **by value** through the existing `FanSpeedReceiveMap`; device-wide lists keep the positional reading. A list whose values are entirely unrecognized falls through to the old behaviour rather than rejecting every speed.

Devices that publish per-mode lists but no device-wide list (like this one) previously fell through to `LegacyFanSpeedSendMap`. They now use their own reported values.

### 3. The `CodeNum` comparison never matched — `mysa-js-sdk`

```ts
return device.CodeNum === CANONICAL_FAN_SPEED_CODE_NUM ? CanonicalFanSpeedSendMap : LegacyFanSpeedSendMap;
```

`DeviceBase.CodeNum` is declared `number`, but the REST API returns it as a **string** — this account's AC-V1-0 reports `"2009"`, quoted, in `/devices`. If that holds generally, `"1117" === 1117` is false and the canonical fallback added in #226 has never been reachable; those devices silently get the legacy `1/3/5/7` values they ignore.

**I can only see one device, so I'd rather ask than assert.** #226 reports an end-to-end verification on an AC-V1-0 where every fan command reached the unit, which is inconsistent with the branch being dead — unless that unit enumerates `fanSpeeds` (in which case the `CodeNum` branch never runs and both things are true). If you have a `CodeNum`-1117 device handy, does `/devices` quote the value? Either way the comparison is now numeric and the type is `number | string`, which is correct regardless.

### 4. Fan-mode commands were validated against the union — `mysa2mqtt`

Home Assistant fixes `fan_modes` at discovery time, so it has to advertise the union across modes; the UI then offers speeds the current mode won't accept. `buildFanModes` validated incoming commands against that same union, so a speed valid in *some* mode was forwarded anyway — and the resulting command carried no usable fanSpeed while still reapplying the current temperature and mode, which is not a no-op. A genuinely unknown speed was dropped with no log line.

`buildFanModes` now takes an optional mode. Discovery still publishes the union (there's no way to vary it per mode); the command handler validates against the current mode and logs a rejected speed with the mode and what that mode supports.

## Tests

Neither `mysa-js-sdk` nor `mysa2mqtt` had a suite, so this adds vitest configs to both, mirroring `mqtt2ha`'s. No new dependencies — vitest is already a root devDependency. 21 tests, using the capabilities above as the fixture.

Reverting just the `CodeNum` coercion and the per-mode preference fails exactly four of them (dry returning every speed, fan-only shifting, per-mode losing to device-wide, and `CodeNum: "1117"` falling back to legacy), so they do pin the behaviour.

`npm run style-lint && npm run lint && npm run build && npm run typecheck && npm test` all pass.

## One judgement call to flag

The fan-speed and mode mapping moved from `MysaApiClient.ts` into a new `src/lib/DeviceCapabilities.ts`. `api/index.ts` does `export * from './MysaApiClient'`, so exporting the helper for tests would have added it to the published API; `lib/` isn't re-exported from the barrel, so this keeps the surface unchanged. Happy to inline it back and mock instead if you'd prefer a smaller diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fan-mode and fan-speed commands are now validated against the thermostat’s current operating mode.
  * Unsupported fan speeds are rejected instead of being ignored, with clearer warnings.
  * Fan-speed mapping now respects per-mode capability lists (including correct handling for AC-V1-X and code values returned as text).
* **New Features**
  * Mode-aware fan-speed list generation is now available for building Home Assistant discovery payloads.
* **Tests**
  * Added coverage for device capability mapping and mode-aware fan behavior.
* **Chores**
  * Added Vitest `test` / `test:watch` scripts and package-level Vitest configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->