### PR TITLE
ci: add a changeset to Dependabot PRs automatically

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -13,6 +13,8 @@ We have a quick list of common questions to get you started engaging with this p
 - `mysa2mqtt` usually does **not** need its own changeset when only a library changed — it is bumped
   automatically because it depends on `mysa-js-sdk` and `mqtt2ha` (see `updateInternalDependencies`
   in `config.json`).
-- Dependency-bump PRs do not get a changeset automatically. If a bump affects a **runtime**
-  dependency, add a `patch` changeset by hand so it reaches users.
+- Dependabot PRs get their changeset from the `Dependabot: add changeset` workflow: a `patch` for
+  each package whose **runtime** dependencies changed, for a `mysa2mqtt` Dockerfile bump, and for a
+  lockfile-only security bump. Replace it by hand if the update warrants more than a patch or a real
+  release note. Bumps with no runtime impact — root dev dependencies, GitHub Actions — get none.
 - Releases happen when the **Version Packages** PR is merged, not when you push to `main`.

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -44,9 +44,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Keying the name on the PR number makes the whole step idempotent:
-          # Dependabot force-pushes when a newer version lands, wiping our
-          # commit, and the resulting `synchronize` rewrites this same path.
+          # Keying the name on the PR number makes the whole step idempotent.
+          # Dependabot force-pushes over our commit when a newer version lands
+          # -- it only keeps doing so because the commit message carries
+          # `[dependabot skip]`, see the last step -- and the resulting
+          # `synchronize` rewrites this same path.
           file=".changeset/dependabot-${PR_NUMBER}.md"
 
           merge_base=$(git merge-base "$BASE_SHA" HEAD)
@@ -59,16 +61,19 @@ jobs:
 
           packages=()
 
-          # A runtime dependency of a workspace package. Comparing the whole
-          # `dependencies` object ignores a devDependencies-only bump and picks
-          # up every package when a group update spans several of them.
+          # A runtime dependency of a workspace package. Comparing whole
+          # dependency objects ignores a devDependencies-only bump and picks up
+          # every package when a group update spans several of them. `optional`
+          # and `peer` are in there because they are equally user-visible; no
+          # manifest declares either today, and missing one would be silent.
+          runtime='[.dependencies, .optionalDependencies, .peerDependencies] | map(. // {}) | add'
           while IFS= read -r f; do
             case "$f" in
               packages/*/package.json)
                 [ -f "$f" ] || continue
                 # A package added by this PR has no base revision to read.
-                old=$(git show "$merge_base:$f" 2>/dev/null | jq -Sc '.dependencies // {}') || old='{}'
-                new=$(jq -Sc '.dependencies // {}' "$f")
+                old=$(git show "$merge_base:$f" 2>/dev/null | jq -Sc "$runtime") || old='{}'
+                new=$(jq -Sc "$runtime" "$f")
                 if [ "$old" != "$new" ]; then
                   packages+=("$(jq -r .name "$f")")
                 fi
@@ -123,5 +128,8 @@ jobs:
           set -euo pipefail
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git commit -m 'chore: add changeset for dependency bump'
+          # `[dependabot skip]`: Dependabot stops updating a branch that carries
+          # a commit by anyone else -- this one is authored by github-actions[bot]
+          # -- and this directive is what lets it keep force-pushing over us.
+          git commit -m 'chore: add changeset for dependency bump [dependabot skip]'
           git push origin "HEAD:$HEAD_REF"

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -1,0 +1,127 @@
+name: 'Dependabot: add changeset'
+
+# Nothing ships without a changeset, and Dependabot does not write one. A
+# runtime bump merged without one sits on main until an unrelated change happens
+# to release that package, so this workflow commits the changeset that used to
+# be added by hand.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-changeset-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changeset:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      # Dependabot-triggered runs get a read-only token unless the workflow asks
+      # for more; this is what lets the changeset be pushed onto the PR branch.
+      # No PAT and no Dependabot secret is involved.
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.head_ref }}
+          # The merge base has to be reachable for the diff below.
+          fetch-depth: 0
+
+      - name: Generate changeset
+        id: generate
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Through the environment, never interpolated into the script body: a
+          # PR title that reaches the shell as source is an injection vector.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          # Keying the name on the PR number makes the whole step idempotent:
+          # Dependabot force-pushes when a newer version lands, wiping our
+          # commit, and the resulting `synchronize` rewrites this same path.
+          file=".changeset/dependabot-${PR_NUMBER}.md"
+
+          merge_base=$(git merge-base "$BASE_SHA" HEAD)
+
+          # Our own file is excluded so a re-run sees the same file set as the
+          # first run -- the "lockfile only" test below depends on that.
+          changed=$(git diff --name-only "$merge_base" HEAD | grep -vFx "$file" || true)
+          echo "Changed files:"
+          echo "$changed"
+
+          packages=()
+
+          # A runtime dependency of a workspace package. Comparing the whole
+          # `dependencies` object ignores a devDependencies-only bump and picks
+          # up every package when a group update spans several of them.
+          while IFS= read -r f; do
+            case "$f" in
+              packages/*/package.json)
+                [ -f "$f" ] || continue
+                # A package added by this PR has no base revision to read.
+                old=$(git show "$merge_base:$f" 2>/dev/null | jq -Sc '.dependencies // {}') || old='{}'
+                new=$(jq -Sc '.dependencies // {}' "$f")
+                if [ "$old" != "$new" ]; then
+                  packages+=("$(jq -r .name "$f")")
+                fi
+                ;;
+            esac
+          done <<< "$changed"
+
+          # A new base image reaches users only as a published mysa2mqtt image,
+          # and an image is published only by a release.
+          if grep -qxF 'packages/mysa2mqtt/Dockerfile' <<< "$changed"; then
+            packages+=('mysa2mqtt')
+          fi
+
+          # Transitive and security bumps rewrite only the lockfile: no manifest
+          # to attribute them to, and the lockfile is what the Docker image
+          # installs from. Requiring it to be the *only* change is what keeps a
+          # root devDependencies bump -- package.json *and* lockfile -- out.
+          if [ "$changed" = 'package-lock.json' ]; then
+            packages+=('mysa2mqtt')
+          fi
+
+          if [ ${#packages[@]} -eq 0 ]; then
+            # Also covers a rebase that turned a releasable PR into a
+            # CI-only one: the stale changeset is removed rather than left.
+            echo 'Nothing user-visible in this update; no changeset needed.'
+            rm -f "$file"
+          else
+            printf 'Bumping: %s\n' "${packages[*]}"
+            {
+              echo '---'
+              printf '%s\n' "${packages[@]}" | sort -u | sed "s/.*/'&': patch/"
+              echo '---'
+              echo
+              printf '%s\n' "$PR_TITLE"
+            } > "$file"
+          fi
+
+          # Only ever the file this workflow owns; a hand-written changeset
+          # already on the branch is left alone.
+          git add -A -- "$file"
+          if git diff --cached --quiet; then
+            echo 'Changeset already up to date.'
+          else
+            echo 'commit=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.generate.outputs.commit == 'true'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -m 'chore: add changeset for dependency bump'
+          git push origin "HEAD:$HEAD_REF"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,9 @@ Guidance:
 - **Usually omit `mysa2mqtt` when only a library changed** — it is bumped automatically as a dependent, and adding a
   redundant entry produces noisy changelogs.
 - Refactors, CI changes and docs need no changeset.
-- Dependency bumps affecting a **runtime** dependency should get a `patch` changeset added by hand.
+- Dependency bumps affecting a **runtime** dependency need a `patch` changeset. On a Dependabot PR the
+  `Dependabot: add changeset` workflow commits one; replace it by hand if the bump warrants more than a patch or a real
+  release note. Bumps with no runtime impact — root dev dependencies, GitHub Actions — get none.
 
 Merging to `main` publishes nothing. It opens a "chore: version packages" PR; publishing happens when a maintainer
 merges that. Do not attempt to publish, tag, or trigger a release.


### PR DESCRIPTION
## Why

Nothing ships without a changeset, and Dependabot doesn't write one. A runtime dependency bump merged without one sits on `main` until some unrelated change happens to release that package — and because nothing fails, a forgotten changeset is invisible. It's been patched by hand so far (#219, #220), and [AGENTS.md](AGENTS.md) documented that as a manual step.

## What

A new `Dependabot: add changeset` workflow that commits the same changeset the maintainer used to add: a `patch` for the affected package, with the PR title as the body. It runs on Dependabot PRs only (`opened`, `synchronize`, `reopened`).

| Change in the PR | Changeset |
| --- | --- |
| `dependencies` / `optionalDependencies` / `peerDependencies` in a `packages/*/package.json` | `patch` for that package — every one of them, for a group update |
| `packages/mysa2mqtt/Dockerfile` | `mysa2mqtt: patch` — a base image reaches users only as a published image |
| `package-lock.json` **and nothing else** | `mysa2mqtt: patch` — transitive/security bumps, no manifest to attribute them to |
| root `devDependencies`, `.github/workflows` | none |

Runtime deps are detected by comparing those dependency objects against the merge base, which is what keeps a `devDependencies`-only bump out. No manifest declares optional or peer dependencies today; they're covered because missing one would be silent — no changeset, no release, no failure. The lockfile rule requires the lockfile to be the *only* change — a root dev-dependency bump touches `package.json` too, as in #221.

`AGENTS.md` is updated to match.

## Notes for review

- **Idempotency.** The file is named `dependabot-<PR#>.md` and is filtered out of the diff before classification, so a re-run sees the same file set the first run did and regenerates a byte-identical file — no empty commits. Dependabot force-pushes over our commit when a newer version lands and the resulting `synchronize` rewrites the same path with the new title — it keeps doing that only because the commit message carries `[dependabot skip]`, without which Dependabot would stop updating a branch that carries someone else's commit.
- **Permissions.** A job-level `contents: write` is what raises Dependabot's otherwise read-only `GITHUB_TOKEN`. No PAT, no Dependabot secret.
- **Injection.** The PR title reaches the script through `env:`, never interpolated into the `run:` body.
- **One accepted trade-off.** A push made with `GITHUB_TOKEN` doesn't trigger further runs, so CI won't re-run on the final SHA — the `main` ruleset requires no status checks, and the added file is a changeset, which can't break the build that already ran on the bump itself.
- Only the file it owns is ever touched — a hand-written changeset already on the branch is left alone.

## Verification

Detection logic replayed against real merged commits:

| Commit | Expected | Got |
| --- | --- | --- |
| #220, #219 (aws-sdk in `mysa-js-sdk` deps) | `mysa-js-sdk` | ✅ |
| #221 (root dev-dependencies group) | none | ✅ |
| #124 (lockfile-only axios) | `mysa2mqtt` | ✅ |
| #231 (GitHub Actions bump) | none | ✅ |
| `712d4c8` (Dockerfile) | `mysa2mqtt` | ✅ |

Plus synthetic cases in a throwaway clone: a workspace `devDependencies`-only bump → none; runtime deps in two packages → both. Idempotency checked by re-running over the workflow's own commit. `bash -n` on both `run` blocks, the generated frontmatter fed through `@changesets/parse`, and `npm run style-lint` passes.

The first real test is the next weekly Dependabot run — `@dependabot recreate` on an open PR forces it sooner.

No changeset on this PR: CI-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated release-note handling for eligible Dependabot updates.
  * Changesets are created or removed automatically based on whether a dependency update requires a release.
  * Existing manually authored changesets are preserved, helping prevent unintended release-note changes.

* **Documentation**
  * Clarified which runtime, Dockerfile, and lockfile updates require patch release notes.
  * Documented that eligible Dependabot updates may receive changesets automatically, while development-only updates do not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
