### PR TITLE
fix(ci): don't let the changeset step die when there is nothing to stage

### DIFF
--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -112,8 +112,14 @@ jobs:
           fi
 
           # Only ever the file this workflow owns; a hand-written changeset
-          # already on the branch is left alone.
-          git add -A -- "$file"
+          # already on the branch is left alone. The guard is not cosmetic:
+          # `git add` exits 128 on a pathspec matching nothing, which is the
+          # most common case of all -- no changeset warranted and none on the
+          # branch. `ls-files` keeps the branch that stages a *deletion*, where
+          # the path is gone from the tree but still in the index.
+          if [ -e "$file" ] || git ls-files --error-unmatch -- "$file" >/dev/null 2>&1; then
+            git add -A -- "$file"
+          fi
           if git diff --cached --quiet; then
             echo 'Changeset already up to date.'
           else


### PR DESCRIPTION
Follow-up to #242. The first real run — [#235](https://github.com/bourquep/mysa2mqtt/pull/235), recreated by hand — [failed](https://github.com/bourquep/mysa2mqtt/actions/runs/30699087511):

```
Changed files:
package-lock.json
package.json
Nothing user-visible in this update; no changeset needed.
fatal: pathspec '.changeset/dependabot-235.md' did not match any files
##[error]Process completed with exit code 128.
```

## Cause

Classification was right — a root `devDependencies` group gets no changeset. The crash is one line later: `git add` exits 128 on a pathspec matching nothing, and "no changeset warranted, none on the branch" is the most common outcome this workflow will ever produce. So every no-op run was going to fail, which is the worst possible thing to get wrong here: a red X on PRs that are behaving exactly as designed.

## Fix

Stage only when the path exists in the tree or in the index:

```bash
if [ -e "$file" ] || git ls-files --error-unmatch -- "$file" >/dev/null 2>&1; then
  git add -A -- "$file"
fi
```

The `ls-files` half is load-bearing: it keeps the branch that stages a *deletion*, where a stale changeset has been removed from the tree but is still tracked.

## Why the tests missed it

#242 validated classification thoroughly and the staging step barely at all — the one idempotency check ran with the file already present. This time I extracted the `Generate changeset` step verbatim from the YAML and ran it against a real clone:

| Scenario | Result |
| --- | --- |
| #235 reproduction — root dev-deps, no changeset present | `exit=0`, no commit ✅ (was `exit=128`) |
| Runtime dep bump | writes the changeset, `commit=true` ✅ |
| Re-run over its own commit | idempotent, no commit ✅ |
| Title changed by a rebase | rewrites the same file, `commit=true` ✅ |
| Stale changeset, PR now dev-deps only | stages `D .changeset/…`, `commit=true` ✅ |

Once this is merged, `@dependabot recreate` on #235 should end green with no commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated change tracking to handle missing or deleted change entries without failing.
  * Preserved existing manually authored change entries during automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->