### PR TITLE
feat: in-floor thermostat now follows air/floor temp based on user setting

### DIFF
--- a/.changeset/in-floor-temperature-source.md
+++ b/.changeset/in-floor-temperature-source.md
@@ -1,0 +1,15 @@
+---
+'mysa-js-sdk': minor
+'mysa2mqtt': minor
+---
+
+Follow the temperature sensor an in-floor heating thermostat (INF-V1-0) is set to regulate against.
+
+These units have both an ambient air sensor and a floor probe, and the Mysa app lets the owner pick which one the
+thermostat tracks — but the climate entity always published the ambient reading. The device reports its selection as the
+`trackedSnsr` status field, which the SDK parsed but never surfaced; it is now exposed as `Status.trackedSensor`, and
+mysa2mqtt publishes the matching reading as the thermostat entity's current temperature. Picking the floor probe in the
+app is all that is needed.
+
+The **Current temperature** and **Floor temperature** sensors are unaffected: each keeps reporting its own probe. The
+selection only rides along on real-time status messages, so the ambient reading is used until the first one arrives.

--- a/packages/mysa-js-sdk/src/api/MysaApiClient.ts
+++ b/packages/mysa-js-sdk/src/api/MysaApiClient.ts
@@ -1,5 +1,10 @@
 import { MysaCredentials } from '@/api/MysaCredentials';
-import { buildFanSpeedSendMap, FanSpeedReceiveMap, ModeSendMap } from '@/lib/DeviceCapabilities';
+import {
+  buildFanSpeedSendMap,
+  FanSpeedReceiveMap,
+  ModeSendMap,
+  TrackedSensorReceiveMap
+} from '@/lib/DeviceCapabilities';
 import { EventEmitter } from '@/lib/EventEmitter';
 import { parseMqttPayload, serializeMqttPayload } from '@/lib/PayloadParser';
 import { isMsgOutPayload, isMsgTypeOutPayload } from '@/lib/PayloadTypeGuards';
@@ -1252,7 +1257,11 @@ export class MysaApiClient {
               humidity: parsedPayload.body.hum,
               setPoint: parsedPayload.body.stpt,
               dutyCycle: parsedPayload.body.heatStat,
-              floorTemperature: parsedPayload.body.flrSnsrTemp
+              floorTemperature: parsedPayload.body.flrSnsrTemp,
+              trackedSensor:
+                parsedPayload.body.trackedSnsr !== undefined
+                  ? TrackedSensorReceiveMap[parsedPayload.body.trackedSnsr]
+                  : undefined
             });
             break;
 
@@ -1266,7 +1275,11 @@ export class MysaApiClient {
               humidity: parsedPayload.body.hum,
               setPoint: parsedPayload.body.stpt,
               dutyCycle: parsedPayload.body.dtyCycle ?? parsedPayload.body.heatStat,
-              floorTemperature: parsedPayload.body.flrSnsrTemp
+              floorTemperature: parsedPayload.body.flrSnsrTemp,
+              trackedSensor:
+                parsedPayload.body.trackedSnsr !== undefined
+                  ? TrackedSensorReceiveMap[parsedPayload.body.trackedSnsr]
+                  : undefined
             });
             break;
 

--- a/packages/mysa-js-sdk/src/api/MysaTrackedSensor.ts
+++ b/packages/mysa-js-sdk/src/api/MysaTrackedSensor.ts
@@ -1,0 +1,8 @@
+/**
+ * Union type representing the temperature sensor an in-floor heating thermostat regulates against.
+ *
+ * In-floor units (`INF-V1-0`) carry both an ambient air sensor in the wall unit and a probe embedded in the floor. The
+ * Mysa app lets the owner pick which one drives the setpoint, and the device echoes that choice back in its status
+ * messages as the raw `trackedSnsr` field.
+ */
+export type MysaTrackedSensor = 'ambient' | 'floor';

--- a/packages/mysa-js-sdk/src/api/events/Status.ts
+++ b/packages/mysa-js-sdk/src/api/events/Status.ts
@@ -1,3 +1,5 @@
+import { MysaTrackedSensor } from '@/api/MysaTrackedSensor';
+
 /**
  * Interface representing the current status of a Mysa device.
  *
@@ -19,4 +21,10 @@ export interface Status {
   dutyCycle?: number;
   /** Optional floor-probe temperature reading, reported only by in-floor heating thermostats (INF-V1-0) */
   floorTemperature?: number;
+  /**
+   * Which sensor the device regulates against, as selected by the owner in the Mysa app. Reported only by in-floor
+   * heating thermostats (INF-V1-0), which have both an ambient sensor and a floor probe; undefined for every other
+   * device family, and for an in-floor unit reporting a selection this SDK does not recognize.
+   */
+  trackedSensor?: MysaTrackedSensor;
 }

--- a/packages/mysa-js-sdk/src/api/index.ts
+++ b/packages/mysa-js-sdk/src/api/index.ts
@@ -6,3 +6,4 @@ export * from './MysaApiClientEventTypes';
 export * from './MysaApiClientOptions';
 export * from './MysaCredentials';
 export * from './MysaDeviceMode';
+export * from './MysaTrackedSensor';

--- a/packages/mysa-js-sdk/src/lib/DeviceCapabilities.ts
+++ b/packages/mysa-js-sdk/src/lib/DeviceCapabilities.ts
@@ -77,7 +77,7 @@ export const FanSpeedReceiveMap: Record<number, MysaFanSpeedMode> = {
  * Receive-side `trackedSnsr`-to-sensor mapping for in-floor heating thermostats (`INF-V1-0`). Any other raw value is
  * left unmapped rather than guessed at, so an unrecognized selection reads as "not reported".
  */
-export const TrackedSensorReceiveMap: Record<number, MysaTrackedSensor> = {
+export const TrackedSensorReceiveMap: Partial<Record<number, MysaTrackedSensor>> = {
   3: 'floor',
   5: 'ambient'
 };

--- a/packages/mysa-js-sdk/src/lib/DeviceCapabilities.ts
+++ b/packages/mysa-js-sdk/src/lib/DeviceCapabilities.ts
@@ -22,6 +22,7 @@ SOFTWARE.
 */
 
 import { MysaDeviceMode, MysaFanSpeedMode } from '@/api/MysaDeviceMode';
+import { MysaTrackedSensor } from '@/api/MysaTrackedSensor';
 import { DeviceBase, SupportedCaps } from '@/types/rest';
 
 /**
@@ -70,6 +71,15 @@ export const FanSpeedReceiveMap: Record<number, MysaFanSpeedMode> = {
   6: 'high', // CodeNum=1117 canonical high
   7: 'high', // legacy
   8: 'max'
+};
+
+/**
+ * Receive-side `trackedSnsr`-to-sensor mapping for in-floor heating thermostats (`INF-V1-0`). Any other raw value is
+ * left unmapped rather than guessed at, so an unrecognized selection reads as "not reported".
+ */
+export const TrackedSensorReceiveMap: Record<number, MysaTrackedSensor> = {
+  3: 'floor',
+  5: 'ambient'
 };
 
 /** Raw `md` values for each mode. Doubles as the key into `SupportedCaps.modes`, which is indexed by the same value. */

--- a/packages/mysa2mqtt/README.md
+++ b/packages/mysa2mqtt/README.md
@@ -185,6 +185,22 @@ A few things to be aware of:
 - Do not use the thermostat's own maximum current rating here. That figure describes what the thermostat is rated to
   switch, which is typically several times more than the heaters connected to it.
 
+### In-floor temperature source
+
+In-floor thermostats (`INF-V1-0`) have two temperature sensors: an ambient air sensor in the wall unit and a probe
+embedded in the floor. The Mysa app lets you choose which one the thermostat regulates against, and **mysa2mqtt follows
+that choice automatically** — pick the floor probe in the app and the **Thermostat** entity's current temperature
+becomes the floor reading, with no configuration needed here.
+
+A few things to be aware of:
+
+- Only the **Thermostat** (climate) entity's current temperature changes. The **Current temperature** and **Floor
+  temperature** sensors are unaffected: each keeps reporting its own probe, so no history is lost either way.
+- The device only reports its selection on real-time status messages. Until the first one arrives after startup — and on
+  accounts where the real-time connection never establishes at all, such as all-Lite fleets kept current by the REST
+  poll alone — the ambient reading is used.
+- Changing the setting in the Mysa app is picked up on the next status message; there is nothing to restart.
+
 ## Usage Examples
 
 ### Using Environment Variables (.env file)

--- a/packages/mysa2mqtt/src/thermostat.ts
+++ b/packages/mysa2mqtt/src/thermostat.ts
@@ -37,6 +37,7 @@ import {
   MysaApiClient,
   MysaDeviceMode,
   MysaFanSpeedMode,
+  MysaTrackedSensor,
   StateChange,
   Status,
   SupportedCaps
@@ -178,6 +179,29 @@ export function buildFanModes(supportedCaps: SupportedCaps | undefined, mode?: M
   );
 }
 
+/**
+ * Decides which temperature sensor drives a thermostat's climate entity.
+ *
+ * Only in-floor units (`INF-V1-0`) have a floor probe, so every other family is always ambient. For an in-floor unit,
+ * follow the sensor the device reports it regulates against, which mirrors the choice its owner made in the Mysa app.
+ *
+ * @param isInFloor - Whether this is an in-floor heating thermostat.
+ * @param reportedTrackedSensor - The sensor the device last reported regulating against. Only ever arrives on realtime
+ *   status messages, so it is undefined until the first one lands — and stays undefined on accounts where the realtime
+ *   stream never connects at all, which is why this falls back to ambient rather than blocking.
+ * @returns The sensor whose reading the climate entity should publish.
+ */
+export function resolveTemperatureSource(
+  isInFloor: boolean,
+  reportedTrackedSensor: MysaTrackedSensor | undefined
+): MysaTrackedSensor {
+  if (!isInFloor) {
+    return 'ambient';
+  }
+
+  return reportedTrackedSensor ?? 'ambient';
+}
+
 export class Thermostat {
   private isStarted = false;
   private realtimeGeneration = 0;
@@ -206,6 +230,15 @@ export class Thermostat {
   };
 
   private readonly deviceType: DeviceType;
+
+  /** True for in-floor heating thermostats (INF-V1-0), the only family with a floor probe. */
+  private readonly isInFloor: boolean;
+  /** The sensor the device last reported regulating against. Undefined until a realtime status message arrives. */
+  private reportedTrackedSensor: MysaTrackedSensor | undefined;
+  /** Latest floor-probe reading, retained so a REST poll cannot drop the climate entity back to the ambient sensor. */
+  private lastFloorTemperature: number | undefined;
+  /** Guards {@link resolveCurrentTemperature}'s fallback warning, which would otherwise repeat on every update. */
+  private warnedAboutMissingFloorTemperature = false;
 
   constructor(
     public readonly mysaApiClient: MysaApiClient,
@@ -244,6 +277,7 @@ export class Thermostat {
     // models, which report `Current` natively today.
     const isV2 = /-v2-/i.test(mysaDevice.Model);
     const isInFloor = /^INF-/i.test(mysaDevice.Model);
+    this.isInFloor = isInFloor;
     const needsHeaterWatts = isV2 || isInFloor;
     const canReportPower = !isAC && (!needsHeaterWatts || heaterWatts != null);
 
@@ -511,7 +545,7 @@ export class Thermostat {
    * @param state - This device's entry from a `getDeviceStates` response.
    */
   private async publishRestState(state: DeviceState): Promise<void> {
-    this.mqttClimate.currentTemperature = state.CorrectedTemp?.v;
+    this.mqttClimate.currentTemperature = this.resolveCurrentTemperature(state.CorrectedTemp?.v);
     this.mqttClimate.currentHumidity = state.Humidity?.v;
     this.mqttClimate.currentMode =
       MYSA_RAW_MODE_TO_DEVICE_MODE[state.TstatMode?.v as number] ?? this.mqttClimate.currentMode;
@@ -545,6 +579,47 @@ export class Thermostat {
     await this.mqttTemperature.setState('state_topic', 'None');
     await this.mqttFloorTemperature?.setState('state_topic', 'None');
     await this.mqttHumidity.setState('state_topic', 'None');
+  }
+
+  /**
+   * Whether the climate entity reports the floor probe rather than the ambient air sensor.
+   *
+   * @returns True when the climate entity should report the floor probe.
+   */
+  private get usesFloorTemperature(): boolean {
+    return resolveTemperatureSource(this.isInFloor, this.reportedTrackedSensor) === 'floor';
+  }
+
+  /**
+   * Picks the reading to publish as the climate entity's current temperature.
+   *
+   * The **Current temperature** and **Floor temperature** sensors are unaffected: each keeps reporting its own probe
+   * regardless of which one drives the climate entity.
+   *
+   * @param ambientTemperature - The ambient air reading from the status message or REST poll being applied.
+   * @returns The floor-probe reading when this thermostat tracks the floor, otherwise the ambient reading.
+   */
+  private resolveCurrentTemperature(ambientTemperature: number | undefined): number | undefined {
+    if (!this.usesFloorTemperature) {
+      return ambientTemperature;
+    }
+
+    if (this.lastFloorTemperature == null) {
+      // Practically unreachable: a device reporting that it regulates against the floor sends the probe reading in the
+      // same message, and the two fields are only independently optional in the payload types. Fall back to ambient
+      // rather than blanking the entity out, but say so once in case some firmware really does split them.
+      if (!this.warnedAboutMissingFloorTemperature) {
+        this.warnedAboutMissingFloorTemperature = true;
+        this.logger.warn(
+          'Device reports that it regulates against the floor probe but has never sent a floor temperature; using the ambient temperature instead',
+          { deviceId: this.mysaDevice.Id, model: this.mysaDevice.Model }
+        );
+      }
+
+      return ambientTemperature;
+    }
+
+    return this.lastFloorTemperature;
   }
 
   private async setDeviceState(setPoint?: number, mode?: MysaDeviceMode, fanSpeed?: MysaFanSpeedMode): Promise<void> {
@@ -618,8 +693,17 @@ export class Thermostat {
       return;
     }
 
+    // Track both before publishing: the device's sensor selection decides which reading the climate entity gets, and
+    // the probe reading has to outlive this message so a later REST poll cannot revert the entity to ambient.
+    if (status.trackedSensor !== undefined) {
+      this.reportedTrackedSensor = status.trackedSensor;
+    }
+    if (status.floorTemperature != null) {
+      this.lastFloorTemperature = status.floorTemperature;
+    }
+
     this.mqttClimate.currentAction = this.computeCurrentAction(status.current, status.dutyCycle);
-    this.mqttClimate.currentTemperature = status.temperature;
+    this.mqttClimate.currentTemperature = this.resolveCurrentTemperature(status.temperature);
     this.mqttClimate.currentHumidity = status.humidity;
     this.mqttClimate.targetTemperature = this.mqttClimate.currentMode !== 'off' ? status.setPoint : undefined;
 

--- a/packages/mysa2mqtt/src/thermostat.ts
+++ b/packages/mysa2mqtt/src/thermostat.ts
@@ -695,6 +695,10 @@ export class Thermostat {
 
     // Track both before publishing: the device's sensor selection decides which reading the climate entity gets, and
     // the probe reading has to outlive this message so a later REST poll cannot revert the entity to ambient.
+    //
+    // Both are guarded rather than assigned unconditionally, for the same reason the fan-mode update in
+    // handleMysaStateChange is: a field missing from one message means "not reported", not "unset". Overwriting with
+    // undefined would drop the climate entity to ambient for a single cycle and flap back on the next status.
     if (status.trackedSensor !== undefined) {
       this.reportedTrackedSensor = status.trackedSensor;
     }

--- a/packages/mysa2mqtt/test/thermostat.test.ts
+++ b/packages/mysa2mqtt/test/thermostat.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 // credential options are absent — which they are under vitest.
 vi.mock('@/options', () => ({ version: '0.0.0-test' }));
 
-const { buildFanModes } = await import('@/thermostat');
+const { buildFanModes, resolveTemperatureSource } = await import('@/thermostat');
 
 /**
  * `SupportedCaps` as actually reported by an AC-V1-0 driving a DAIKIN mini-split (caps version 1.2). No device-wide
@@ -92,5 +92,24 @@ describe('buildFanModes', () => {
     const caps: SupportedCaps = { tempRange: [16, 30], version: '1.2', keys: [3], modes: {} };
 
     expect(buildFanModes(caps)).toEqual(['auto']);
+  });
+});
+
+describe('resolveTemperatureSource', () => {
+  it('follows the sensor an in-floor thermostat reports regulating against', () => {
+    expect(resolveTemperatureSource(true, 'floor')).toBe('floor');
+    expect(resolveTemperatureSource(true, 'ambient')).toBe('ambient');
+  });
+
+  it('uses ambient for an in-floor thermostat that has not reported a selection yet', () => {
+    // The selection only rides along on realtime status messages, which have not arrived at startup and never arrive
+    // at all on accounts whose realtime stream cannot connect. Ambient is the pre-existing behaviour.
+    expect(resolveTemperatureSource(true, undefined)).toBe('ambient');
+  });
+
+  it('never reports floor for a device that has no floor probe', () => {
+    // Baseboard V2 units share the status message type that carries the selection, but never populate the field.
+    expect(resolveTemperatureSource(false, undefined)).toBe('ambient');
+    expect(resolveTemperatureSource(false, 'floor')).toBe('ambient');
   });
 });


### PR DESCRIPTION
## What this does

In-floor heating thermostats (`INF-V1-0`) have two temperature sensors: an ambient air sensor in the wall unit and a probe embedded in the floor. The Mysa app lets the owner choose which one the thermostat regulates against.

mysa2mqtt always published the **ambient** reading as the climate entity's current temperature. So a thermostat configured to track the floor showed Home Assistant a temperature it wasn't actually controlling on — and the setpoint appeared to be ignored, because it was being applied to the other sensor.

The device already reports its selection in the `trackedSnsr` status field. The SDK parsed it into the payload types but never surfaced it, so nothing downstream could act on it. This exposes it as `Status.trackedSensor` and has the climate entity follow it.

**No configuration needed** — pick the sensor in the Mysa app and the climate entity matches it.

## Changes

**`mysa-js-sdk`**

- New `MysaTrackedSensor` type (`'ambient' | 'floor'`) and a `TrackedSensorReceiveMap` alongside the existing receive-side maps.
- `Status.trackedSensor`, populated from `trackedSnsr` on both status message types that carry it (`DEVICE_IN_FLOOR_STATUS` / msg 17 and `DEVICE_V2_STATUS` / msg 40).
- Unrecognised raw values are left unmapped rather than guessed at, so an unfamiliar selection reads as "not reported" instead of silently becoming one of the two known values.

**`mysa2mqtt`**

- The climate entity's current temperature follows the device's reported selection, via a small exported pure function `resolveTemperatureSource`.
- The REST poll needed guarding. `publishRestState` writes `CorrectedTemp` (ambient) into the climate entity on every poll, so without this the reading would have snapped back to air temperature every 60 seconds. Both the realtime and REST paths now resolve the source through one code path, and the last floor reading is retained so the poll can't revert it.
- Falls back to ambient when the selection is unknown — before the first realtime status arrives, and on accounts where the realtime connection never establishes at all (all-Lite fleets, which are kept current by the REST poll alone). This is the pre-existing behaviour, so nothing regresses for those users.

## Testing

Verified against a real `INF-V1-0`, in both directions.

With the app set to **floor**:

```
climate/…/current_temperature    23.9   ← floor probe
sensor/…/floor_temperature       23.90
sensor/…/temperature             20.80  ← ambient air
```

Over two minutes the climate value tracked the floor probe through every change (23.9 → 24.0 → 23.8) and never showed the ambient 20.8. Switching the app to **ambient** moved it to 20.8, where it then stayed pinned while the floor probe oscillated between 23.8 and 24.0 across twelve updates.

**The device corroborated the mapping itself.** Same setpoint (22.0 °C) and same two readings, but its reported action changed with the selection:

| App setting | `current_temperature` | Device action | Consistent because |
| --- | --- | --- | --- |
| Floor | 23.9 (floor) | `idle` | 23.9 > 22.0, satisfied |
| Ambient | 20.8 (air) | `heating` | 20.8 < 22.0, calls for heat |

A thermostat regulating on air at 20.8 °C with a 22.0 °C setpoint must call for heat. It sat idle when set to floor. That's independent confirmation that `3 = floor` / `5 = ambient` is correct, rather than an assumption carried over from the type annotations.

The REST-poll guard was verified separately by monitoring across multiple 60-second poll cycles with no reversion to ambient.

Also ran: `npm run style-lint`, `npm run lint`, `npm run build`, `npm run typecheck`, `npm test` — all clean, 122 tests passing.

## Notes for review

- A changeset is included (`mysa-js-sdk` minor, `mysa2mqtt` minor).
- `resolveTemperatureSource` is exported purely so it can be unit tested — `test/thermostat.test.ts` doesn't instantiate `Thermostat`, so that's the established pattern in this file.
- One limitation worth naming: `trackedSnsr` only rides along on realtime status messages, and there's no REST equivalent. On accounts where the realtime stream never connects, in-floor thermostats will always show ambient. I looked at adding an environment-variable override for that case and decided against shipping it — it's config surface for a situation that may not affect anyone in practice.

## Follow-up

I am working on a second PR that will be stacked on this one, adding a Home Assistant `select` entity to change the source from Home Assistant rather than the Mysa app. It depends on the SDK groundwork here, so it'll be opened as a draft and rebased once this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Climate temperature readings now follow the thermostat’s selected ambient or floor sensor.
  * In-floor thermostats retain floor-temperature readings between updates.
  * Real-time status updates automatically refresh the selected temperature source.

* **Bug Fixes**
  * Ambient temperature is used as a fallback when floor data is unavailable or before the first status update.

* **Documentation**
  * Added guidance on temperature-source behavior and startup fallback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->