### PR TITLE
feat: for in floor thermostats a user can now select the thermostat temperature source ambient or floor

### DIFF
--- a/.changeset/in-floor-temperature-source-control.md
+++ b/.changeset/in-floor-temperature-source-control.md
@@ -1,0 +1,16 @@
+---
+'mysa-js-sdk': minor
+'mysa2mqtt': minor
+---
+
+Choose which sensor an in-floor heating thermostat (INF-V1-0) regulates against, from Home Assistant.
+
+These units have both an ambient air sensor and a floor probe. mysa2mqtt already reported which one the thermostat was
+tracking; now it can change it. In-floor thermostats gain a **Temperature source** dropdown with `Ambient` and `Floor`
+options, and picking one applies the setting to the device itself — the same change the Mysa app makes, so it also
+changes what the thermostat heats to. Changing it in the app updates the dropdown within a few seconds.
+
+The SDK gains `MysaApiClient.setTrackedSensor(deviceId, sensor)`, which sends the `tr` command field decoded from the
+Mysa app's own traffic, and rejects devices that have no floor probe with a new `UnsupportedTrackedSensorError`. The
+device's acknowledgement is surfaced as `StateChange.trackedSensor`, so a change is reflected in about a second rather
+than waiting for the next periodic status message.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # mysa2mqtt
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 

--- a/packages/mysa-js-sdk/src/api/Errors.ts
+++ b/packages/mysa-js-sdk/src/api/Errors.ts
@@ -78,6 +78,26 @@ export class UnsupportedFanSpeedError extends Error {
   }
 }
 
+/** Error thrown when a device has no selectable temperature sensor to track. */
+export class UnsupportedTrackedSensorError extends Error {
+  /**
+   * Creates a new UnsupportedTrackedSensorError instance.
+   *
+   * @param deviceId - The id of the device the command was aimed at.
+   * @param model - The device's model, which determines whether it has a floor probe at all.
+   */
+  constructor(
+    public readonly deviceId: string,
+    public readonly model: string
+  ) {
+    super(
+      `Device '${deviceId}' (model '${model}') has no selectable temperature sensor. Only in-floor heating ` +
+        `thermostats (INF-V1-0) have both an ambient sensor and a floor probe.`
+    );
+    this.name = 'UnsupportedTrackedSensorError';
+  }
+}
+
 /** Error thrown when an MQTT publish ultimately fails after retry attempts. */
 export class MqttPublishError extends Error {
   /**

--- a/packages/mysa-js-sdk/src/api/MysaApiClient.ts
+++ b/packages/mysa-js-sdk/src/api/MysaApiClient.ts
@@ -428,10 +428,11 @@ export class MysaApiClient {
    * @param fanSpeed - The fan speed mode to set ('low', 'medium', 'high', 'max', 'auto', or undefined to leave
    *   unchanged).
    * @param trackedSensor - The sensor an in-floor thermostat should regulate against, or undefined to leave unchanged.
-   *   Accepted as-is: prefer {@link setTrackedSensor}, which rejects devices that have no floor probe.
    * @throws {@link UnauthenticatedError} When the client cannot authenticate with its credentials.
    * @throws {@link UnknownDeviceError} When the device id does not match any device on the account.
    * @throws {@link UnsupportedFanSpeedError} When the requested fan speed is not supported by the device.
+   * @throws {@link UnsupportedTrackedSensorError} When a tracked sensor is requested for a device that has no floor
+   *   probe to select.
    * @throws {@link Error} When MQTT connection or command sending fails.
    */
   async setDeviceState(
@@ -473,6 +474,13 @@ export class MysaApiClient {
     // which the caller would perceive as a no-op.
     if (fanSpeed !== undefined && fanSpeedMap[fanSpeed] === undefined) {
       throw new UnsupportedFanSpeedError(deviceId, fanSpeed, Object.keys(fanSpeedMap));
+    }
+
+    // Likewise for the tracked sensor: only in-floor units have a second sensor to choose between, and every other
+    // family silently ignores `tr`. Matching the family rather than an exact model keeps a future in-floor revision
+    // working, consistent with how the rest of the codebase tests for device families.
+    if (trackedSensor !== undefined && !/^INF-/i.test(device.Model)) {
+      throw new UnsupportedTrackedSensorError(deviceId, device.Model);
     }
 
     const payload = serializeMqttPayload<ChangeDeviceState>({
@@ -545,23 +553,6 @@ export class MysaApiClient {
    * @throws {@link Error} When MQTT connection or command sending fails.
    */
   async setTrackedSensor(deviceId: string, trackedSensor: MysaTrackedSensor) {
-    if (!this._cachedDevices) {
-      this._cachedDevices = await this.getDevices();
-    }
-
-    // Own-property check, matching setDeviceState: an inherited key such as 'constructor' would otherwise reach
-    // device.Model below and fail with a TypeError instead of UnknownDeviceError.
-    if (!Object.prototype.hasOwnProperty.call(this._cachedDevices.DevicesObj, deviceId)) {
-      throw new UnknownDeviceError(deviceId);
-    }
-
-    // Every other family has a single sensor, so `tr` would be silently ignored by the device. Reject it here rather
-    // than publish a command that looks like it worked.
-    const model = this._cachedDevices.DevicesObj[deviceId].Model;
-    if (!/^INF-/i.test(model)) {
-      throw new UnsupportedTrackedSensorError(deviceId, model);
-    }
-
     await this.setDeviceState(deviceId, undefined, undefined, undefined, trackedSensor);
   }
 

--- a/packages/mysa-js-sdk/src/api/MysaApiClient.ts
+++ b/packages/mysa-js-sdk/src/api/MysaApiClient.ts
@@ -3,7 +3,8 @@ import {
   buildFanSpeedSendMap,
   FanSpeedReceiveMap,
   ModeSendMap,
-  TrackedSensorReceiveMap
+  TrackedSensorReceiveMap,
+  TrackedSensorSendMap
 } from '@/lib/DeviceCapabilities';
 import { EventEmitter } from '@/lib/EventEmitter';
 import { parseMqttPayload, serializeMqttPayload } from '@/lib/PayloadParser';
@@ -26,12 +27,14 @@ import {
   MysaApiError,
   UnauthenticatedError,
   UnknownDeviceError,
-  UnsupportedFanSpeedError
+  UnsupportedFanSpeedError,
+  UnsupportedTrackedSensorError
 } from './Errors';
 import { Logger, VoidLogger } from './Logger';
 import { MysaApiClientEventTypes } from './MysaApiClientEventTypes';
 import { MysaApiClientOptions } from './MysaApiClientOptions';
 import { MysaDeviceMode, MysaFanSpeedMode } from './MysaDeviceMode';
+import { MysaTrackedSensor } from './MysaTrackedSensor';
 
 dayjs.extend(duration);
 
@@ -424,12 +427,20 @@ export class MysaApiClient {
    * @param mode - The operating mode to set (one of MysaDeviceMode values, or undefined to leave unchanged).
    * @param fanSpeed - The fan speed mode to set ('low', 'medium', 'high', 'max', 'auto', or undefined to leave
    *   unchanged).
+   * @param trackedSensor - The sensor an in-floor thermostat should regulate against, or undefined to leave unchanged.
+   *   Accepted as-is: prefer {@link setTrackedSensor}, which rejects devices that have no floor probe.
    * @throws {@link UnauthenticatedError} When the client cannot authenticate with its credentials.
    * @throws {@link UnknownDeviceError} When the device id does not match any device on the account.
    * @throws {@link UnsupportedFanSpeedError} When the requested fan speed is not supported by the device.
    * @throws {@link Error} When MQTT connection or command sending fails.
    */
-  async setDeviceState(deviceId: string, setPoint?: number, mode?: MysaDeviceMode, fanSpeed?: MysaFanSpeedMode) {
+  async setDeviceState(
+    deviceId: string,
+    setPoint?: number,
+    mode?: MysaDeviceMode,
+    fanSpeed?: MysaFanSpeedMode,
+    trackedSensor?: MysaTrackedSensor
+  ) {
     this._logger.debug(`Setting device state for '${deviceId}'`);
 
     if (!this._cachedDevices) {
@@ -497,7 +508,8 @@ export class MysaApiClient {
             tm: -1,
             sp: setPoint,
             md: mode ? ModeSendMap[mode] : undefined,
-            fn: fanSpeed ? fanSpeedMap[fanSpeed] : undefined
+            fn: fanSpeed ? fanSpeedMap[fanSpeed] : undefined,
+            tr: trackedSensor ? TrackedSensorSendMap[trackedSensor] : undefined
           }
         ]
       }
@@ -510,6 +522,47 @@ export class MysaApiClient {
       this._logger.error(`Failed to set device state for '${deviceId}'`, error);
       throw error;
     }
+  }
+
+  /**
+   * Chooses which temperature sensor an in-floor heating thermostat regulates against.
+   *
+   * In-floor units (INF-V1-0) carry both an ambient air sensor and a probe embedded in the floor, and this selects
+   * between them — the same setting the Mysa app exposes. The device confirms the change on its next status message via
+   * {@link Status.trackedSensor}, and immediately via {@link StateChange.trackedSensor}.
+   *
+   * @example
+   *
+   * ```typescript
+   * await client.setTrackedSensor('device123', 'floor');
+   * ```
+   *
+   * @param deviceId - The ID of the in-floor thermostat to control.
+   * @param trackedSensor - The sensor to regulate against.
+   * @throws {@link UnauthenticatedError} When the client cannot authenticate with its credentials.
+   * @throws {@link UnknownDeviceError} When the device id does not match any device on the account.
+   * @throws {@link UnsupportedTrackedSensorError} When the device is not an in-floor thermostat.
+   * @throws {@link Error} When MQTT connection or command sending fails.
+   */
+  async setTrackedSensor(deviceId: string, trackedSensor: MysaTrackedSensor) {
+    if (!this._cachedDevices) {
+      this._cachedDevices = await this.getDevices();
+    }
+
+    // Own-property check, matching setDeviceState: an inherited key such as 'constructor' would otherwise reach
+    // device.Model below and fail with a TypeError instead of UnknownDeviceError.
+    if (!Object.prototype.hasOwnProperty.call(this._cachedDevices.DevicesObj, deviceId)) {
+      throw new UnknownDeviceError(deviceId);
+    }
+
+    // Every other family has a single sensor, so `tr` would be silently ignored by the device. Reject it here rather
+    // than publish a command that looks like it worked.
+    const model = this._cachedDevices.DevicesObj[deviceId].Model;
+    if (!/^INF-/i.test(model)) {
+      throw new UnsupportedTrackedSensorError(deviceId, model);
+    }
+
+    await this.setDeviceState(deviceId, undefined, undefined, undefined, trackedSensor);
   }
 
   /**
@@ -1297,7 +1350,11 @@ export class MysaApiClient {
               mode: parsedPayload.body.state.md ? modeMap[parsedPayload.body.state.md] : undefined,
               setPoint: parsedPayload.body.state.sp,
               fanSpeed:
-                parsedPayload.body.state.fn !== undefined ? FanSpeedReceiveMap[parsedPayload.body.state.fn] : undefined
+                parsedPayload.body.state.fn !== undefined ? FanSpeedReceiveMap[parsedPayload.body.state.fn] : undefined,
+              trackedSensor:
+                parsedPayload.body.state.tr !== undefined
+                  ? TrackedSensorReceiveMap[parsedPayload.body.state.tr]
+                  : undefined
             });
             break;
           }

--- a/packages/mysa-js-sdk/src/api/events/StateChange.ts
+++ b/packages/mysa-js-sdk/src/api/events/StateChange.ts
@@ -1,4 +1,5 @@
 import { MysaDeviceMode, MysaFanSpeedMode } from '@/api/MysaDeviceMode';
+import { MysaTrackedSensor } from '@/api/MysaTrackedSensor';
 
 /**
  * Interface representing a device state change event for a Mysa device.
@@ -16,4 +17,9 @@ export interface StateChange {
   setPoint: number;
   /** Optional fan speed (1 = auto, 3 = low, 5 = medium, 7 = high, 8 = max). AC only */
   fanSpeed?: MysaFanSpeedMode;
+  /**
+   * Which sensor the device regulates against, when it reports one. In-floor heating thermostats (INF-V1-0) only.
+   * Arrives as soon as the selection changes, rather than on the next periodic status message.
+   */
+  trackedSensor?: MysaTrackedSensor;
 }

--- a/packages/mysa-js-sdk/src/lib/DeviceCapabilities.ts
+++ b/packages/mysa-js-sdk/src/lib/DeviceCapabilities.ts
@@ -82,6 +82,15 @@ export const TrackedSensorReceiveMap: Partial<Record<number, MysaTrackedSensor>>
   5: 'ambient'
 };
 
+/**
+ * Send-side sensor-to-`tr` mapping, the inverse of {@link TrackedSensorReceiveMap}. The command field (`tr`) and the
+ * status field (`trackedSnsr`) share an encoding, so a value written here reads back unchanged.
+ */
+export const TrackedSensorSendMap: Record<MysaTrackedSensor, number> = {
+  floor: 3,
+  ambient: 5
+};
+
 /** Raw `md` values for each mode. Doubles as the key into `SupportedCaps.modes`, which is indexed by the same value. */
 export const ModeSendMap: Record<MysaDeviceMode, number> = { off: 1, auto: 2, heat: 3, cool: 4, fan_only: 5, dry: 6 };
 

--- a/packages/mysa-js-sdk/src/types/mqtt/in/ChangeDeviceState.ts
+++ b/packages/mysa-js-sdk/src/types/mqtt/in/ChangeDeviceState.ts
@@ -38,6 +38,12 @@ export interface ChangeDeviceState extends MsgPayload<InMessageType.CHANGE_DEVIC
         tm: number;
         /** Optional fan speed (1 = auto, 3 = low, 5 = medium, 7 = high, 8 = max). AC only */
         fn?: number;
+        /**
+         * Optional selection of the sensor the thermostat regulates against (3 = floor probe, 5 = ambient air).
+         * In-floor heating thermostats (INF-V1-0) only, being the only family with both. Shares its encoding with the
+         * `trackedSnsr` status field the device reports back.
+         */
+        tr?: number;
       }
     ];
     /**

--- a/packages/mysa-js-sdk/src/types/mqtt/out/DeviceStateChange.ts
+++ b/packages/mysa-js-sdk/src/types/mqtt/out/DeviceStateChange.ts
@@ -31,6 +31,12 @@ export interface DeviceStateChange extends MsgPayload<OutMessageType.DEVICE_STAT
       sp: number;
       /** Optional fan speed (1 = auto, 3 = low, 5 = medium, 7 = high, 8 = max). AC only */
       fn?: number;
+      /**
+       * Optional sensor the thermostat regulates against (3 = floor probe, 5 = ambient air). Reported by in-floor
+       * heating thermostats (INF-V1-0) only, and echoed here as soon as the selection changes — ahead of the next
+       * periodic status message.
+       */
+      tr?: number;
     };
     /** Success indicator for the state change operation (1 = success, 0 = failure) */
     success: number;

--- a/packages/mysa-js-sdk/test/DeviceCapabilities.test.ts
+++ b/packages/mysa-js-sdk/test/DeviceCapabilities.test.ts
@@ -1,4 +1,5 @@
-import { buildFanSpeedSendMap } from '@/lib/DeviceCapabilities';
+import { MysaTrackedSensor } from '@/api/MysaTrackedSensor';
+import { buildFanSpeedSendMap, TrackedSensorReceiveMap, TrackedSensorSendMap } from '@/lib/DeviceCapabilities';
 import { DeviceBase, SupportedCaps } from '@/types/rest';
 import { describe, expect, it } from 'vitest';
 
@@ -123,5 +124,20 @@ describe('buildFanSpeedSendMap', () => {
     it('uses the legacy map when no CodeNum is reported', () => {
       expect(buildFanSpeedSendMap(device())).toEqual({ auto: 1, low: 3, medium: 5, high: 7, max: 8 });
     });
+  });
+});
+
+describe('tracked sensor maps', () => {
+  // The raw values were decoded from a real INF-V1-0: the `tr` command field and the `trackedSnsr` status field share
+  // an encoding, so a written value reads back unchanged. Anything that breaks that round trip would silently invert
+  // the setting.
+  it('round-trips every sensor through the send and receive maps', () => {
+    for (const sensor of Object.keys(TrackedSensorSendMap) as MysaTrackedSensor[]) {
+      expect(TrackedSensorReceiveMap[TrackedSensorSendMap[sensor]]).toBe(sensor);
+    }
+  });
+
+  it('uses the raw values observed on the wire', () => {
+    expect(TrackedSensorSendMap).toEqual({ floor: 3, ambient: 5 });
   });
 });

--- a/packages/mysa2mqtt/README.md
+++ b/packages/mysa2mqtt/README.md
@@ -188,18 +188,24 @@ A few things to be aware of:
 ### In-floor temperature source
 
 In-floor thermostats (`INF-V1-0`) have two temperature sensors: an ambient air sensor in the wall unit and a probe
-embedded in the floor. The Mysa app lets you choose which one the thermostat regulates against, and **mysa2mqtt follows
-that choice automatically** — pick the floor probe in the app and the **Thermostat** entity's current temperature
-becomes the floor reading, with no configuration needed here.
+embedded in the floor. Which one the thermostat regulates against is a device setting, and mysa2mqtt exposes it as a
+**Temperature source** dropdown with two options, `Ambient` and `Floor`.
+
+Changing it in Home Assistant changes it on the thermostat, exactly as the Mysa app does — this is the real setting, not
+a display preference, so it also changes what the device heats to. Changing it in the app instead updates the dropdown
+within a few seconds. The **Thermostat** entity's current temperature follows the selection either way.
 
 A few things to be aware of:
 
 - Only the **Thermostat** (climate) entity's current temperature changes. The **Current temperature** and **Floor
   temperature** sensors are unaffected: each keeps reporting its own probe, so no history is lost either way.
-- The device only reports its selection on real-time status messages. Until the first one arrives after startup — and on
-  accounts where the real-time connection never establishes at all, such as all-Lite fleets kept current by the REST
-  poll alone — the ambient reading is used.
-- Changing the setting in the Mysa app is picked up on the next status message; there is nothing to restart.
+- The device only reports its selection on real-time status messages. Until the first one arrives after startup, the
+  dropdown reads unknown and the ambient reading is used. On accounts where the real-time connection never establishes
+  at all — such as all-Lite fleets, kept current by the REST poll alone — the setting cannot be read or changed, since
+  the REST API does not carry it.
+- The dropdown always converges on what the thermostat reports. If a change does not reach the device, it reverts within
+  a few seconds rather than sitting on a value that was never applied.
+- Only in-floor thermostats get this entity; every other model has a single sensor and nothing to choose between.
 
 ## Usage Examples
 

--- a/packages/mysa2mqtt/src/thermostat.ts
+++ b/packages/mysa2mqtt/src/thermostat.ts
@@ -28,6 +28,7 @@ import {
   Logger,
   MqttSettings,
   OriginConfiguration,
+  Select,
   Sensor
 } from 'mqtt2ha';
 import {
@@ -202,6 +203,35 @@ export function resolveTemperatureSource(
   return reportedTrackedSensor ?? 'ambient';
 }
 
+/**
+ * The label the temperature-source select entity shows for each sensor, in the order Home Assistant lists them.
+ *
+ * A Home Assistant select has no separate display name for an option, so these labels are also the entity's state. They
+ * are capitalized for presentation and therefore differ from the SDK's lowercase {@link MysaTrackedSensor} values, which
+ * every published state and accepted command has to be translated through.
+ */
+export const TEMPERATURE_SOURCE_LABELS: Record<MysaTrackedSensor, string> = {
+  ambient: 'Ambient',
+  floor: 'Floor'
+};
+
+/**
+ * Parses a temperature-source command payload received from Home Assistant.
+ *
+ * The select component hands its callback the raw message even when it is not one of the configured options — it warns
+ * and drops the value from its own state, then invokes the callback regardless — so the payload has to be validated
+ * here before anything is sent to the thermostat. Matching is exact, labels included: Home Assistant only ever sends
+ * back a string it was given in `options`.
+ *
+ * @param message - The raw payload published to the command topic.
+ * @returns The requested sensor, or undefined when the payload is not one this entity offers.
+ */
+export function parseTemperatureSource(message: string): MysaTrackedSensor | undefined {
+  return (Object.keys(TEMPERATURE_SOURCE_LABELS) as MysaTrackedSensor[]).find(
+    (trackedSensor) => TEMPERATURE_SOURCE_LABELS[trackedSensor] === message
+  );
+}
+
 export class Thermostat {
   private isStarted = false;
   private realtimeGeneration = 0;
@@ -213,6 +243,10 @@ export class Thermostat {
   private readonly mqttTemperature: Sensor;
   /** Floor-probe temperature, published only for in-floor heating thermostats (INF-V1-0). */
   private readonly mqttFloorTemperature: Sensor | undefined;
+  /** Chooses which sensor the thermostat regulates against. In-floor heating thermostats (INF-V1-0) only. */
+  private readonly mqttTemperatureSource: Select | undefined;
+  /** Set instead of {@link mqttTemperatureSource} on devices with one sensor, to retire a previously published entity. */
+  private readonly mqttRetiredTemperatureSource: Select | undefined;
   private readonly mqttHumidity: Sensor;
   private readonly mqttPower: Sensor | undefined;
   /** Set instead of {@link mqttPower} when this device cannot report power, to retire a previously published entity. */
@@ -424,6 +458,30 @@ export class Thermostat {
         })
       : undefined;
 
+    // Built unconditionally so a device that should not expose it can still clear a config published by an earlier
+    // run — the discovery topic is retained, so an entity left behind never disappears on its own.
+    const temperatureSourceSelect = new Select(
+      {
+        mqtt: this.mqttSettings,
+        logger: this.logger,
+        component: {
+          component: 'select',
+          device: this.mqttDevice,
+          origin: this.mqttOrigin,
+          unique_id: `mysa_${mysaDevice.Id}_temperature_source`,
+          name: 'Temperature source',
+          options: Object.values(TEMPERATURE_SOURCE_LABELS),
+          entity_category: 'config'
+        }
+      },
+      async (_topic, message) => {
+        await this.handleTemperatureSourceCommand(message);
+      }
+    );
+
+    this.mqttTemperatureSource = isInFloor ? temperatureSourceSelect : undefined;
+    this.mqttRetiredTemperatureSource = isInFloor ? undefined : temperatureSourceSelect;
+
     this.mqttHumidity = new Sensor({
       mqtt: this.mqttSettings,
       logger: this.logger,
@@ -496,6 +554,14 @@ export class Thermostat {
         await this.mqttPower.writeConfig();
       }
       await this.mqttRetiredPower?.removeConfig();
+
+      // The device only reports its selection over the realtime stream, so publish 'None' ahead of the discovery
+      // config rather than let a retained value from an earlier run stand in for a reading we do not have yet.
+      if (this.mqttTemperatureSource != null) {
+        await this.mqttTemperatureSource.setState('state_topic', 'None');
+        await this.mqttTemperatureSource.writeConfig();
+      }
+      await this.mqttRetiredTemperatureSource?.removeConfig();
 
       this.mysaApiClient.emitter.on('statusChanged', this.mysaStatusUpdateHandler);
       this.mysaApiClient.emitter.on('stateChanged', this.mysaStateChangeHandler);
@@ -579,6 +645,8 @@ export class Thermostat {
     await this.mqttTemperature.setState('state_topic', 'None');
     await this.mqttFloorTemperature?.setState('state_topic', 'None');
     await this.mqttHumidity.setState('state_topic', 'None');
+    // 'None' is not one of the configured options, so setSelectedOption would warn and drop it.
+    await this.mqttTemperatureSource?.setState('state_topic', 'None');
   }
 
   /**
@@ -620,6 +688,56 @@ export class Thermostat {
     }
 
     return this.lastFloorTemperature;
+  }
+
+  /**
+   * Applies a temperature-source command from Home Assistant.
+   *
+   * The select component applies the requested option to its own state before this runs and never reverts it — it has
+   * no optimistic flag to turn off — so both the rejection and the failure path have to republish the truth explicitly,
+   * or Home Assistant is left showing a selection the thermostat never accepted.
+   *
+   * @param message - The raw payload published to the command topic.
+   */
+  private async handleTemperatureSourceCommand(message: string): Promise<void> {
+    const requested = parseTemperatureSource(message);
+
+    if (requested === undefined) {
+      this.logger.warn('Ignoring an unrecognized temperature source command', {
+        deviceId: this.mysaDevice.Id,
+        message
+      });
+      await this.republishTemperatureSource();
+      return;
+    }
+
+    try {
+      await this.mysaApiClient.setTrackedSensor(this.mysaDevice.Id, requested);
+    } catch (error) {
+      this.logger.error('Failed to change the tracked sensor', {
+        error,
+        deviceId: this.mysaDevice.Id,
+        trackedSensor: requested
+      });
+      await this.republishTemperatureSource();
+    }
+  }
+
+  /**
+   * Republishes the sensor the device last reported regulating against, discarding whatever the select entity is
+   * currently showing.
+   *
+   * Publishes nothing but `'None'` when no selection has been reported yet. Unlike {@link resolveTemperatureSource},
+   * which must pick some temperature for the climate entity to display, this entity reports the device's own setting
+   * and must not invent one.
+   */
+  private async republishTemperatureSource(): Promise<void> {
+    if (this.reportedTrackedSensor === undefined) {
+      await this.mqttTemperatureSource?.setState('state_topic', 'None');
+      return;
+    }
+
+    await this.mqttTemperatureSource?.setSelectedOption(TEMPERATURE_SOURCE_LABELS[this.reportedTrackedSensor]);
   }
 
   private async setDeviceState(setPoint?: number, mode?: MysaDeviceMode, fanSpeed?: MysaFanSpeedMode): Promise<void> {
@@ -701,6 +819,9 @@ export class Thermostat {
     // undefined would drop the climate entity to ambient for a single cycle and flap back on the next status.
     if (status.trackedSensor !== undefined) {
       this.reportedTrackedSensor = status.trackedSensor;
+      // Republished on every status rather than only on change: the device reports its selection every few seconds,
+      // so this is what pulls the select entity back into line after a lost write or a change made in the Mysa app.
+      await this.mqttTemperatureSource?.setSelectedOption(TEMPERATURE_SOURCE_LABELS[status.trackedSensor]);
     }
     if (status.floorTemperature != null) {
       this.lastFloorTemperature = status.floorTemperature;
@@ -727,6 +848,13 @@ export class Thermostat {
   private async handleMysaStateChange(state: StateChange) {
     if (!this.isStarted || state.deviceId !== this.mysaDevice.Id) {
       return;
+    }
+
+    // The device acknowledges a tracked-sensor change here, about a second after the command and well ahead of the
+    // next periodic status, so this is what makes the select entity feel responsive.
+    if (state.trackedSensor !== undefined) {
+      this.reportedTrackedSensor = state.trackedSensor;
+      await this.mqttTemperatureSource?.setSelectedOption(TEMPERATURE_SOURCE_LABELS[state.trackedSensor]);
     }
 
     switch (state.mode) {

--- a/packages/mysa2mqtt/test/thermostat.test.ts
+++ b/packages/mysa2mqtt/test/thermostat.test.ts
@@ -5,7 +5,8 @@ import { describe, expect, it, vi } from 'vitest';
 // credential options are absent — which they are under vitest.
 vi.mock('@/options', () => ({ version: '0.0.0-test' }));
 
-const { buildFanModes, resolveTemperatureSource } = await import('@/thermostat');
+const { buildFanModes, parseTemperatureSource, resolveTemperatureSource, TEMPERATURE_SOURCE_LABELS } =
+  await import('@/thermostat');
 
 /**
  * `SupportedCaps` as actually reported by an AC-V1-0 driving a DAIKIN mini-split (caps version 1.2). No device-wide
@@ -111,5 +112,28 @@ describe('resolveTemperatureSource', () => {
     // Baseboard V2 units share the status message type that carries the selection, but never populate the field.
     expect(resolveTemperatureSource(false, undefined)).toBe('ambient');
     expect(resolveTemperatureSource(false, 'floor')).toBe('ambient');
+  });
+});
+
+describe('temperature source labels', () => {
+  it('advertises capitalized labels', () => {
+    expect(TEMPERATURE_SOURCE_LABELS).toEqual({ ambient: 'Ambient', floor: 'Floor' });
+  });
+
+  it('parses back every label it publishes', () => {
+    // The invariant that matters: Home Assistant only ever echoes a string from `options`, and setSelectedOption
+    // silently drops anything outside that list. If the two sides ever diverge the entity stops working entirely.
+    for (const trackedSensor of ['ambient', 'floor'] as const) {
+      expect(parseTemperatureSource(TEMPERATURE_SOURCE_LABELS[trackedSensor])).toBe(trackedSensor);
+    }
+  });
+
+  it('rejects anything that is not an advertised label', () => {
+    // The select component hands its callback the raw payload even when it is not a configured option, so these all
+    // reach this function. Passing one through would publish a command with no sensor set. The lowercase spellings
+    // are the SDK's own MysaTrackedSensor values — close enough to the labels to be worth pinning down.
+    for (const payload of ['', ' ', 'floor', 'ambient', 'FLOOR', 'None', 'null', 'true', '3', 'Floor ', '{"tr":3}']) {
+      expect(parseTemperatureSource(payload)).toBeUndefined();
+    }
   });
 });


### PR DESCRIPTION
> **Draft — stacked on #245.** This branches off `feat/in-floor-tracked-sensor` and needs the `MysaTrackedSensor` / `Status.trackedSensor` groundwork from it. I'll rebase onto `main` and mark this ready for review once #245 merges; until then the diff below also contains that PR's two commits.

## What this does

In-floor heating thermostats (`INF-V1-0`) regulate against either their ambient air sensor or a probe embedded in the floor. The preceding PR made mysa2mqtt *report* which one is selected. This makes it changeable: those devices gain a **Temperature source** select entity with `Ambient` and `Floor` options.

This is the real device setting, not a display preference — changing it changes what the thermostat heats to, exactly as the Mysa app does. Changing it in the app instead updates the dropdown within a few seconds.

## How the write path was found

Capturing the app's own MQTT traffic while toggling the setting showed it uses a previously undocumented **`tr`** field inside that same command, sharing the `3` = floor / `5` = ambient encoding of the `trackedSnsr` status field:

```jsonc
// app → /v1/dev/{id}/in
{"msg":44, "body":{"ver":1,"type":3,"cmd":[{"tm":-1,"tr":5}]}}   // ambient
```

A setpoint change was captured first as a control, to confirm the command channel was actually observable before drawing conclusions from what appeared on it.

Two findings from that capture are deliberately reflected in the implementation:

**The app's redundant `md` is not replicated.** It follows each `tr` with an `md` carrying the *same* number — `tr:5` then `md:5`. The device ignores it: `state.md` was unchanged in every acknowledgement, and the acknowledgement to the `tr` command already reported the new selection *before* the `md` message was sent. Copying it would be pointless at best and harmful at worst, since `md: 5` means `fan_only` in `ModeSendMap` — any firmware that did honour it would flip the climate entity's mode.

**The acknowledgement is used.** The device replies on `/out` within about a second with `success: 1` and the new `state.tr`, well ahead of its next periodic status. That's surfaced as `StateChange.trackedSensor`, so the entity updates promptly instead of after a status cycle.

## Changes

**`mysa-js-sdk`**

- `MysaApiClient.setTrackedSensor(deviceId, sensor)`. It delegates to `setDeviceState`, which already resolves the device, refreshes the session, computes `body.type` (`INF-V1` → `3`, which was already correct) and publishes with retry.
- `TrackedSensorSendMap`, the inverse of the existing receive map, and `tr` on the `ChangeDeviceState` command type.
- `UnsupportedTrackedSensorError`, thrown for devices with no floor probe — the field is silently ignored by other families, so rejecting beats publishing a command that looks like it worked.
- `tr` on `DeviceStateChange`, surfaced as `StateChange.trackedSensor`.

**`mysa2mqtt`**

- The **Temperature source** select, created only for in-floor devices, with a retirement twin following the `mqttPower` / `mqttRetiredPower` pattern so a config published by an earlier run is cleared rather than left orphaned.
- Two hazards in the `Select` component are handled explicitly, and both are worth a look during review:
  - It invokes the command callback with the **raw payload even when that payload is not a configured option** — `setSelectedOption` warns and drops it, then the callback runs anyway. Without validation, junk on the command topic would reach the SDK as `undefined` and publish a command with no sensor set. Payloads are parsed through an exported `parseTemperatureSource` first.
  - It has no `optimistic` flag and applies the option before awaiting the callback, never reverting. So rejection and failure both republish the device's actual selection. This deliberately bypasses the existing `setDeviceState` helper in `thermostat.ts`, which swallows errors.
- The entity converges on the device's reported state from both the status stream and the acknowledgement, so a lost write self-corrects within a status cycle.
- `publishRestState` is untouched — REST carries no tracked-sensor field, so involving it would only let a 60-second poll overwrite fresher realtime truth.
- Publishes `None` before the discovery config and on shutdown, so it reads unknown rather than guessing before the first status arrives.

## Testing

Verified against a real `INF-V1-0`, driving the entity from the MQTT command topic while capturing the wire traffic.

**The published command is identical to the app's**, and there is exactly one of them:

```jsonc
// mysa2mqtt → /v1/dev/{id}/in
{"msg":44, ..., "body":{"ver":1,"type":3,"cmd":[{"tm":-1,"tr":5}]}}
// device → /out, ~200 ms later
{"body":{"success":1,"type":3,"trig_src":3,"state":{"md":3,"sp":22.0,"lk":0,"ho":1,"br":80,"tr":5}}}
```

Note `md` is still `3` in the reply — mode is unaffected, which was the specific regression to watch for.

| Action | Result |
| --- | --- |
| Command `Ambient` | Device switched; `current_temperature` 24.4 → 20.6, action `idle` → `heating` |
| Command `Floor` | Device switched back; 20.6 → 24.4, action `heating` → `idle` (~2 s, via the acknowledgement) |
| Command `floor` (lowercase) | Logged and ignored, entity left on `Floor`, **nothing published to the device** |

The action flip is the strongest signal: ambient sits at 20.6 °C against a 22.0 °C setpoint so the device must call for heat, while the floor probe at 24.4 °C is satisfied. `mode_state` stayed `heat` across both switches.

Also confirmed: only the in-floor thermostat has the entity — the three other devices on the account have no `select` topics retained.

Unit tests cover `parseTemperatureSource` (including the payloads that reach it because the component doesn't filter them), a round trip between every published label and the value it parses back to, and a round trip between the send and receive maps — so neither pairing can drift apart.

`npm run style-lint`, `npm run lint`, `npm run build`, `npm run typecheck`, `npm test` all pass — 127 tests.

## Notes for review

- A changeset is included (`mysa-js-sdk` minor, `mysa2mqtt` minor).
- I went with `select` rather than `switch`: `state: "Floor"` is self-describing in automations, where `state: "on"` would not say which sensor it meant.
- The options are capitalized for presentation, and a Home Assistant select has no separate display label — `options` *are* the entity's state. So they deliberately differ from the SDK's lowercase `MysaTrackedSensor` values, and everything published or accepted is translated through a label map rather than passing the domain value straight out.
- Each entity opens its own MQTT client, so this adds one broker connection per in-floor thermostat. Consistent with how the existing entities work, but worth flagging.
- The capture also revealed a `/v1/dev/{id}/batch` topic (`msg: 3`, base64 telemetry) and `lk` / `ho` / `br` state fields — lock, hold and display brightness — which look controllable the same way. Out of scope here; happy to open an issue if that's of interest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * In-floor thermostats can now switch between Ambient and Floor temperature sources in Home Assistant.
  * The selected temperature source stays synchronized with the thermostat’s reported state.

* **Bug Fixes**
  * Unsupported thermostats no longer expose an unusable temperature-source control.
  * Invalid or failed selections now restore the device-reported setting.

* **Documentation**
  * Added guidance on temperature-source behavior, availability, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->