### PR TITLE
fix(mysa2mqtt): record a heartbeat after every successful REST state poll

### DIFF
--- a/.changeset/heartbeat-rest-poll.md
+++ b/.changeset/heartbeat-rest-poll.md
@@ -2,7 +2,8 @@
 'mysa2mqtt': patch
 ---
 
-Record a `--heartbeat-file` beat after every successful REST state poll, not only on real-time messages.
+Record a `--heartbeat-file` beat on successful REST state polls, not only on real-time messages. Writes stay throttled
+to one per 10 seconds, so a poll that follows a real-time message closely does not write again.
 
 A thermostat that is unplugged, powered off or off the network stops the real-time stream while mysa2mqtt itself stays
 healthy and keeps polling. The heartbeat file then went stale, so a liveness probe watching its mtime restarted the

--- a/.changeset/heartbeat-rest-poll.md
+++ b/.changeset/heartbeat-rest-poll.md
@@ -1,0 +1,16 @@
+---
+'mysa2mqtt': patch
+---
+
+Record a `--heartbeat-file` beat after every successful REST state poll, not only on real-time messages.
+
+A thermostat that is unplugged, powered off or off the network stops the real-time stream while mysa2mqtt itself stays
+healthy and keeps polling. The heartbeat file then went stale, so a liveness probe watching its mtime restarted the
+process every few minutes for as long as the thermostat stayed offline — restarts that could not fix anything, and that
+re-authenticated against the Mysa cloud each time.
+
+The heartbeat now means "mysa2mqtt can still reach the Mysa cloud", which is what a liveness probe can usefully act on.
+Detection of a wedged real-time connection is unaffected in practice: since REST polling was added, a wedged real-time
+path no longer freezes Home Assistant, and the poll fails alongside the real-time stream whenever the cause is on
+mysa2mqtt's side. Accounts that disable polling with `--poll-interval-seconds 0` keep the previous real-time-only
+behaviour.

--- a/packages/mysa2mqtt/README.md
+++ b/packages/mysa2mqtt/README.md
@@ -150,13 +150,13 @@ take precedence over command-line defaults.
 
 #### Application Settings
 
-| CLI Option               | Environment Variable   | Default  | Description                                                                                                                                                 |
-| ------------------------ | ---------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-l, --log-level`        | `M2M_LOG_LEVEL`        | `info`   | Log level: `silent`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`                                                                                     |
-| `-f, --log-format`       | `M2M_LOG_FORMAT`       | `pretty` | Log format: `pretty`, `json`                                                                                                                                |
-| `-t, --temperature-unit` | `M2M_TEMPERATURE_UNIT` | `C`      | Temperature unit (`C` = Celsius, `F` = Fahrenheit)                                                                                                          |
-| `--heater-watts`         | `M2M_HEATER_WATTS`     | -        | Rated wattage of the heaters controlled by each thermostat, as a comma-separated list of `<device>=<watts>` pairs (see [Power reporting](#power-reporting)) |
-| `--heartbeat-file`       | `M2M_HEARTBEAT_FILE`   | -        | File touched on every message received from the Mysa cloud, for external liveness checks (e.g. a container liveness probe on its mtime)                     |
+| CLI Option               | Environment Variable   | Default  | Description                                                                                                                                                                                           |
+| ------------------------ | ---------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-l, --log-level`        | `M2M_LOG_LEVEL`        | `info`   | Log level: `silent`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`                                                                                                                               |
+| `-f, --log-format`       | `M2M_LOG_FORMAT`       | `pretty` | Log format: `pretty`, `json`                                                                                                                                                                          |
+| `-t, --temperature-unit` | `M2M_TEMPERATURE_UNIT` | `C`      | Temperature unit (`C` = Celsius, `F` = Fahrenheit)                                                                                                                                                    |
+| `--heater-watts`         | `M2M_HEATER_WATTS`     | -        | Rated wattage of the heaters controlled by each thermostat, as a comma-separated list of `<device>=<watts>` pairs (see [Power reporting](#power-reporting))                                           |
+| `--heartbeat-file`       | `M2M_HEARTBEAT_FILE`   | -        | File touched whenever the Mysa cloud is reached — on every real-time message and after every successful REST state poll — for external liveness checks (e.g. a container liveness probe on its mtime) |
 
 ### Power reporting
 

--- a/packages/mysa2mqtt/README.md
+++ b/packages/mysa2mqtt/README.md
@@ -150,13 +150,13 @@ take precedence over command-line defaults.
 
 #### Application Settings
 
-| CLI Option               | Environment Variable   | Default  | Description                                                                                                                                                                                           |
-| ------------------------ | ---------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-l, --log-level`        | `M2M_LOG_LEVEL`        | `info`   | Log level: `silent`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`                                                                                                                               |
-| `-f, --log-format`       | `M2M_LOG_FORMAT`       | `pretty` | Log format: `pretty`, `json`                                                                                                                                                                          |
-| `-t, --temperature-unit` | `M2M_TEMPERATURE_UNIT` | `C`      | Temperature unit (`C` = Celsius, `F` = Fahrenheit)                                                                                                                                                    |
-| `--heater-watts`         | `M2M_HEATER_WATTS`     | -        | Rated wattage of the heaters controlled by each thermostat, as a comma-separated list of `<device>=<watts>` pairs (see [Power reporting](#power-reporting))                                           |
-| `--heartbeat-file`       | `M2M_HEARTBEAT_FILE`   | -        | File touched whenever the Mysa cloud is reached — on every real-time message and after every successful REST state poll — for external liveness checks (e.g. a container liveness probe on its mtime) |
+| CLI Option               | Environment Variable   | Default  | Description                                                                                                                                                                                                                     |
+| ------------------------ | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-l, --log-level`        | `M2M_LOG_LEVEL`        | `info`   | Log level: `silent`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`                                                                                                                                                         |
+| `-f, --log-format`       | `M2M_LOG_FORMAT`       | `pretty` | Log format: `pretty`, `json`                                                                                                                                                                                                    |
+| `-t, --temperature-unit` | `M2M_TEMPERATURE_UNIT` | `C`      | Temperature unit (`C` = Celsius, `F` = Fahrenheit)                                                                                                                                                                              |
+| `--heater-watts`         | `M2M_HEATER_WATTS`     | -        | Rated wattage of the heaters controlled by each thermostat, as a comma-separated list of `<device>=<watts>` pairs (see [Power reporting](#power-reporting))                                                                     |
+| `--heartbeat-file`       | `M2M_HEARTBEAT_FILE`   | -        | File touched whenever the Mysa cloud is reached — on real-time messages and on successful REST state polls, throttled to one write per 10 seconds — for external liveness checks (e.g. a container liveness probe on its mtime) |
 
 ### Power reporting
 

--- a/packages/mysa2mqtt/src/heartbeat.ts
+++ b/packages/mysa2mqtt/src/heartbeat.ts
@@ -1,0 +1,74 @@
+/*
+mysa2mqtt
+Copyright (C) 2025-2026 Pascal Bourque
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import { writeFile } from 'fs/promises';
+import pino from 'pino';
+
+/**
+ * Minimum interval between two heartbeat writes.
+ *
+ * Real-time messages arrive far more often than a liveness probe needs, and every beat is a disk write.
+ */
+export const HEARTBEAT_THROTTLE_MS = 10_000;
+
+/** Records a heartbeat. Safe to call from any code path, as often as that path runs. */
+export type HeartbeatRecorder = () => void;
+
+/**
+ * Creates the heartbeat recorder that external liveness checks watch.
+ *
+ * The returned function writes the current timestamp to `heartbeatFile`, throttled to one write per
+ * {@link HEARTBEAT_THROTTLE_MS}. Call it from every path that proves mysa2mqtt can still reach the Mysa cloud — both
+ * real-time messages and successful REST polls — so that a probe watching the file's mtime measures reachability rather
+ * than whether a thermostat happens to be transmitting. A thermostat that is unplugged or off the network stops the
+ * real-time stream while mysa2mqtt itself is healthy, and restarting the process cannot fix that.
+ *
+ * Write failures are logged and swallowed: a heartbeat is diagnostic, and failing to record one must never take down
+ * the bridge.
+ *
+ * @param heartbeatFile - Path to write, from `--heartbeat-file`. Heartbeats are disabled when undefined.
+ * @param logger - Logger for write failures.
+ * @returns A recorder, or undefined when no heartbeat file was configured.
+ */
+export function createHeartbeatRecorder(
+  heartbeatFile: string | undefined,
+  logger: pino.Logger
+): HeartbeatRecorder | undefined {
+  if (!heartbeatFile) {
+    return undefined;
+  }
+
+  let lastBeat = 0;
+
+  return () => {
+    const now = Date.now();
+    if (now - lastBeat < HEARTBEAT_THROTTLE_MS) {
+      return;
+    }
+
+    lastBeat = now;
+    writeFile(heartbeatFile, `${new Date(now).toISOString()}\n`).catch((error) => {
+      logger.warn(error, `Failed to write heartbeat file '${heartbeatFile}'`);
+    });
+  };
+}

--- a/packages/mysa2mqtt/src/main.ts
+++ b/packages/mysa2mqtt/src/main.ts
@@ -23,10 +23,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-import { writeFile } from 'fs/promises';
 import { MqttSettings } from 'mqtt2ha';
 import { DeviceBase, MysaApiClient, UnauthenticatedError } from 'mysa-js-sdk';
 import { pino } from 'pino';
+import { createHeartbeatRecorder, HeartbeatRecorder } from './heartbeat';
 import { PinoLogger } from './logger';
 import { options } from './options';
 import { Thermostat } from './thermostat';
@@ -61,23 +61,13 @@ async function main() {
     { logger: new PinoLogger(rootLogger.child({ module: 'mysa-js-sdk' })) }
   );
 
-  const heartbeatFile = options.heartbeatFile;
-  if (heartbeatFile) {
-    // Data-freshness heartbeat: an orchestrator liveness probe can compare
-    // this file's mtime against the expected message cadence (devices report
-    // at least every ~5 minutes while keep-alives flow) and restart the
-    // process when the Mysa cloud connection wedges without emitting errors.
-    let lastBeat = 0;
-    client.emitter.on('rawRealtimeMessageReceived', () => {
-      const now = Date.now();
-      if (now - lastBeat < 10_000) {
-        return;
-      }
-      lastBeat = now;
-      writeFile(heartbeatFile, `${new Date(now).toISOString()}\n`).catch((error) => {
-        rootLogger.warn(error, `Failed to write heartbeat file '${heartbeatFile}'`);
-      });
-    });
+  // Liveness heartbeat: an orchestrator probe can compare this file's mtime
+  // against the expected cadence and restart the process when it can no longer
+  // reach the Mysa cloud. Both paths to the cloud record a beat — real-time
+  // messages and successful REST state polls.
+  const recordHeartbeat = createHeartbeatRecorder(options.heartbeatFile, rootLogger);
+  if (recordHeartbeat) {
+    client.emitter.on('rawRealtimeMessageReceived', recordHeartbeat);
   }
 
   rootLogger.info('Logging in...');
@@ -177,7 +167,7 @@ async function main() {
     scheduleThermostatStartRetry(thermostat);
   }
 
-  startStatePolling(client, thermostats);
+  startStatePolling(client, thermostats, recordHeartbeat);
 }
 
 /**
@@ -188,10 +178,18 @@ async function main() {
  * fetches the whole account's state and fans it out to every thermostat, so the request cost is independent of fleet
  * size. Disabled when the interval is 0.
  *
+ * A successful poll also records a heartbeat, so the liveness signal tracks whether the process can still reach the
+ * Mysa cloud rather than whether a thermostat happens to be transmitting.
+ *
  * @param client - Authenticated Mysa API client.
  * @param thermostats - The thermostats to refresh.
+ * @param recordHeartbeat - Heartbeat recorder to call after each successful poll, when configured.
  */
-function startStatePolling(client: MysaApiClient, thermostats: Thermostat[]): void {
+function startStatePolling(
+  client: MysaApiClient,
+  thermostats: Thermostat[],
+  recordHeartbeat: HeartbeatRecorder | undefined
+): void {
   const intervalSeconds = options.pollIntervalSeconds;
   if (intervalSeconds <= 0 || thermostats.length === 0) {
     return;
@@ -215,6 +213,7 @@ function startStatePolling(client: MysaApiClient, thermostats: Thermostat[]): vo
     void (async () => {
       try {
         const deviceStates = await client.getDeviceStates();
+        recordHeartbeat?.();
         await Promise.all(
           Array.from(thermostatsById, ([deviceId, thermostat]) =>
             thermostat.refreshFromRest(deviceStates.DeviceStatesObj[deviceId])

--- a/packages/mysa2mqtt/src/options.ts
+++ b/packages/mysa2mqtt/src/options.ts
@@ -225,7 +225,7 @@ export const options = new Command('mysa2mqtt')
   .addOption(
     new Option(
       '--heartbeat-file <heartbeatFile>',
-      'file touched whenever the Mysa cloud is reached — on every real-time message and after every successful REST state poll — for external liveness checks'
+      'file touched whenever the Mysa cloud is reached — on real-time messages and on successful REST state polls, throttled to one write per 10 seconds — for external liveness checks'
     )
       .env('M2M_HEARTBEAT_FILE')
       .helpGroup('Configuration')

--- a/packages/mysa2mqtt/src/options.ts
+++ b/packages/mysa2mqtt/src/options.ts
@@ -225,7 +225,7 @@ export const options = new Command('mysa2mqtt')
   .addOption(
     new Option(
       '--heartbeat-file <heartbeatFile>',
-      'file touched on every message received from the Mysa cloud, for external liveness checks'
+      'file touched whenever the Mysa cloud is reached — on every real-time message and after every successful REST state poll — for external liveness checks'
     )
       .env('M2M_HEARTBEAT_FILE')
       .helpGroup('Configuration')

--- a/packages/mysa2mqtt/test/heartbeat.test.ts
+++ b/packages/mysa2mqtt/test/heartbeat.test.ts
@@ -1,0 +1,83 @@
+import pino from 'pino';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const writeFile = vi.hoisted(() => vi.fn<(path: string, data: string) => Promise<void>>());
+vi.mock('fs/promises', () => ({ writeFile }));
+
+const { createHeartbeatRecorder, HEARTBEAT_THROTTLE_MS } = await import('@/heartbeat');
+
+/** A logger that captures warnings instead of writing them, so the failure path can be asserted on. */
+function createTestLogger() {
+  const warnings: string[] = [];
+  const logger = { warn: (_error: unknown, message: string) => void warnings.push(message) };
+  return { logger: logger as unknown as pino.Logger, warnings };
+}
+
+/** Lets the fire-and-forget promise chain inside the recorder settle. */
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('createHeartbeatRecorder', () => {
+  beforeEach(() => {
+    writeFile.mockReset();
+    writeFile.mockResolvedValue(undefined);
+    // Only Date is faked: the recorder's write completes on a real setImmediate turn.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-07T14:16:35.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('is disabled when no heartbeat file is configured', () => {
+    expect(createHeartbeatRecorder(undefined, createTestLogger().logger)).toBeUndefined();
+    expect(createHeartbeatRecorder('', createTestLogger().logger)).toBeUndefined();
+  });
+
+  it('writes the current timestamp', async () => {
+    const record = createHeartbeatRecorder('/run/heartbeat', createTestLogger().logger);
+
+    record?.();
+    await settle();
+
+    expect(writeFile).toHaveBeenCalledExactlyOnceWith('/run/heartbeat', '2026-08-07T14:16:35.000Z\n');
+  });
+
+  it('throttles repeat beats inside the window', async () => {
+    const record = createHeartbeatRecorder('/run/heartbeat', createTestLogger().logger);
+
+    record?.();
+    // Real-time messages can arrive several times a second; only the first should reach the disk.
+    vi.setSystemTime(new Date(Date.now() + HEARTBEAT_THROTTLE_MS - 1));
+    record?.();
+    await settle();
+
+    expect(writeFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('records again once the window has elapsed', async () => {
+    const record = createHeartbeatRecorder('/run/heartbeat', createTestLogger().logger);
+
+    record?.();
+    vi.setSystemTime(new Date(Date.now() + HEARTBEAT_THROTTLE_MS));
+    record?.();
+    await settle();
+
+    expect(writeFile).toHaveBeenCalledTimes(2);
+    expect(writeFile).toHaveBeenLastCalledWith('/run/heartbeat', '2026-08-07T14:16:45.000Z\n');
+  });
+
+  it('logs and swallows a write failure rather than rejecting', async () => {
+    const { logger, warnings } = createTestLogger();
+    writeFile.mockRejectedValue(new Error('ENOENT'));
+
+    const record = createHeartbeatRecorder('/run/heartbeat', logger);
+
+    expect(() => record?.()).not.toThrow();
+    await settle();
+
+    expect(warnings).toEqual([`Failed to write heartbeat file '/run/heartbeat'`]);
+  });
+});


### PR DESCRIPTION
Follow-on to #183, which added `--heartbeat-file`, and to #126, which added the 60s REST state poll. The two never met: the beat is recorded only from `rawRealtimeMessageReceived`, so the heartbeat measures whether a thermostat is transmitting rather than whether mysa2mqtt can reach the Mysa cloud.

## The failure

A thermostat that is unplugged, powered off, or off the network stops the real-time stream. mysa2mqtt itself stays healthy and keeps polling successfully — Home Assistant stays current, because that is exactly what #126 is for — but the heartbeat file goes stale, and a liveness probe watching its mtime restarts the process.

Restarting cannot fix it, so this repeats for as long as the thermostat stays offline. On my deployment (`AC-V1-0`, k8s probe of `find /tmp/mysa2mqtt-heartbeat -mmin -15`, `initialDelaySeconds: 300`, `failureThreshold: 3`) one accidentally unplugged thermostat produced **74 restarts over 10 hours**, one roughly every 8 minutes, each one re-authenticating against the Mysa cloud. At `--log-level warn` the container emitted nothing at all across all 74 starts, so the only evidence was the restart counter.

## The change

A successful `getDeviceStates()` now records a beat as well. The heartbeat means "mysa2mqtt can still reach the Mysa cloud", which is a condition a restart can plausibly act on. A failed poll records nothing, so a genuinely stuck process is still caught.

The recorder moved to `heartbeat.ts` so both call sites share one throttle, and so it can be unit-tested at all — `main.ts` runs `main()` at import time, so nothing defined in it is reachable from a test.

## Tradeoff

This narrows what the probe detects: a wedged real-time connection whose REST poll still succeeds will no longer trigger a restart. I think that is the right call now — since #126, a wedged real-time path no longer freezes Home Assistant, which was the 9-days-of-frozen-data symptom that motivated #183 — but it is a real change in meaning for anyone relying on the old behaviour, hence the changeset note. Accounts running `--poll-interval-seconds 0` are unaffected and keep the real-time-only heartbeat.

## Verification

`npm run style-lint && npm run lint && npm run build && npm run typecheck` all pass from a clean `npm ci`, and `npm test` is green at 27 files / 132 tests — 5 of them new, covering the disabled case, the write, the throttle window on both sides, and the log-and-swallow failure path. `fs/promises` is mocked and only `Date` is faked, so the new tests touch neither the filesystem nor real timers.

Not tested against a live account beyond my own deployment.

Heads-up: `AGENTS.md` still says "There are no tests" and tells agents not to run `npm test`. That has been out of date since vitest landed; happy to fix it in a separate PR rather than bundle it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The heartbeat file is now updated after each successful REST state poll, in addition to real-time Mysa messages.
  - Heartbeat updates are throttled to avoid unnecessary file writes.
  - Write failures are logged without interrupting operation.

- **Documentation**
  - Updated the `--heartbeat-file` option documentation to describe the expanded heartbeat behavior.
  - Clarified that disabling REST polling preserves real-time-only heartbeat updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->