### PR TITLE
fix(ci): read the changesets v2 `published-packages` output

### DIFF
--- a/.changeset/release-docker-image-3-2-3.md
+++ b/.changeset/release-docker-image-3-2-3.md
@@ -1,0 +1,6 @@
+---
+'mysa2mqtt': patch
+---
+
+Publish a Docker image for the current release. 3.2.2 shipped to npm without one because the release workflow read a
+`changesets/action` output that v2 had renamed, leaving the version empty and skipping the image build.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       id-token: write # npm provenance
     outputs:
       published: ${{ steps.changesets.outputs.published }}
-      published_packages: ${{ steps.changesets.outputs.publishedPackages }}
+      published_packages: ${{ steps.changesets.outputs.published-packages }}
       mysa2mqtt_version: ${{ steps.m2m.outputs.version }}
 
     steps:
@@ -66,7 +66,7 @@ jobs:
         id: m2m
         if: steps.changesets.outputs.published == 'true'
         env:
-          PUBLISHED: ${{ steps.changesets.outputs.publishedPackages }}
+          PUBLISHED: ${{ steps.changesets.outputs.published-packages }}
         run: |
           version=$(echo "$PUBLISHED" | jq -r '.[] | select(.name=="mysa2mqtt") | .version')
           echo "version=$version" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

[#269](https://github.com/bourquep/mysa2mqtt/pull/269) bumped `changesets/action` v1 → v2, which renamed the action's `publishedPackages` output to `published-packages`. The release workflow still read the old name.

In release run [33509073920](https://github.com/bourquep/mysa2mqtt/actions/runs/33509073920) (`mysa2mqtt@3.2.2`) this shows up in the log as:

```
release  Run version=$(echo "$PUBLISHED" | jq ...
release    PUBLISHED:
```

Empty payload → `mysa2mqtt_version` resolved to an empty string → the `docker` job's `needs.release.outputs.mysa2mqtt_version != ''` guard skipped it. **3.2.2 published to npm with no Docker image.**

The `comment` job hit the same empty payload from the other job output, so it reported success while posting no "released in" comments.

## Fix

Read `published-packages` in both places. No behaviour change beyond the outputs resolving again.

Includes a patch changeset for `mysa2mqtt`, since the workflow fix on its own publishes nothing — a release run with no changesets finds everything already on npm, and 3.2.2 would stay imageless. Merging this cuts 3.2.3, which exercises the fixed path and produces the image.

## Verification

The output name is confirmed against [`changesets/action`'s `action.yml`](https://github.com/changesets/action/blob/main/action.yml) at the `v2` tag. Hyphenated output names work in dot notation (same shape as the widely used `steps.cache.outputs.cache-hit`).

`prettier -c` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)